### PR TITLE
Feature spentsearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 cmake-build-debug
 bin\*
+bin\stream\*
 build
 build\*
 src\Version.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ SET(CMAKE_CXX_FLAGS "-std=c++11 -g -Wall")
 SET(MAJOR_VERSION 0)
 SET(MINOR_VERSION 2)
 SET(PATCH_VERSION 1)
-SET(SO_VERSION    6)
+SET(SO_VERSION    7)
 
 # Add source directory
 include_directories(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ SET(CMAKE_CXX_FLAGS "-std=c++11 -g -Wall")
 # Set version number
 SET(MAJOR_VERSION 0)
 SET(MINOR_VERSION 2)
-SET(PATCH_VERSION 1)
-SET(SO_VERSION    7)
+SET(PATCH_VERSION 2)
+SET(SO_VERSION    0)
 
 # Add source directory
 include_directories(src)

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -1,32 +1,48 @@
 #include "BitcoinRpcServer.h"
-#include "ChainAnalyzer.h"
 #include "Config.h"
 #include "Database.h"
 #include "DigiByteCore.h"
-#include "IPFS.h"
-#include "Log.h"
 #include <iostream>
+#include <jsonrpccpp/client.h>
 
 
 int main(int argc, char* argv[]) {
     if (argc < 2) return 1;
 
-    //get input
+    //get command
     string command = argv[1];
-    Value args = Value(Json::arrayValue);
+
+    // Prepare to parse arguments into JSON
+    Json::Value args = Json::arrayValue;
+    Json::Reader reader;
+
     for (int i = 2; i < argc; ++i) {
-        // Try to convert the argument to a number
-        char* endptr;
-        double num = strtod(argv[i], &endptr);
-        if (*endptr == '\0') {
-            // Successfully converted to a number
-            args.append(Json::Value(num));
-        } else if (string(argv[i]) == "true" || string(argv[i]) == "false") {
-            // Handle "true" and "false" as bool values
-            args.append(Json::Value(argv[i] == string("true")));
+        std::string argStr(argv[i]);
+        Json::Value parsedValue;
+
+        // Check if the argument could be a JSON array or object
+        if ((argStr.front() == '[' && argStr.back() == ']') || (argStr.front() == '{' && argStr.back() == '}')) {
+            bool parsingSuccessful = reader.parse(argStr, parsedValue);
+            if (parsingSuccessful) {
+                // If it's a JSON array or object, append it directly
+                args.append(parsedValue);
+            } else {
+                // Parsing failed, treat as a string
+                args.append(argStr);
+            }
         } else {
-            // Otherwise, treat it as a string
-            args.append(Json::Value(argv[i]));
+            // For non-JSON strings, attempt to parse as number or boolean
+            char* endptr;
+            double num = strtod(argv[i], &endptr);
+            if (*endptr == '\0') {
+                args.append(num);
+            } else if (argStr == "true") {
+                args.append(true);
+            } else if (argStr == "false") {
+                args.append(false);
+            } else {
+                args.append(argStr);
+            }
         }
     }
 

--- a/src/AppMain.cpp
+++ b/src/AppMain.cpp
@@ -87,3 +87,15 @@ PermanentStoragePoolList* AppMain::getPermanentStoragePoolList() {
     }
     return _psp;
 }
+
+void AppMain::setChainAnalyzer(ChainAnalyzer* analyzer) {
+    _analyzer = analyzer;
+}
+ChainAnalyzer* AppMain::getChainAnalyzer() {
+    if (_analyzer == nullptr) {
+        Log* log = Log::GetInstance();
+        log->addMessage("Tried to get Chain Analyzer without first loading", Log::CRITICAL);
+        throw runtime_error("Not available");
+    }
+    return _analyzer;
+}

--- a/src/AppMain.h
+++ b/src/AppMain.h
@@ -7,6 +7,7 @@
 
 
 
+#include "ChainAnalyzer.h"
 #include "Database.h"
 #include "PermanentStoragePool/PermanentStoragePoolList.h"
 #include <mutex>
@@ -37,6 +38,7 @@ private:
     IPFS* _ipfs = nullptr;
     DigiByteCore* _dgb = nullptr;
     PermanentStoragePoolList* _psp = nullptr;
+    ChainAnalyzer* _analyzer = nullptr;
 
 public:
     void setDatabase(Database* db);
@@ -51,6 +53,9 @@ public:
 
     void setPermanentStoragePoolList(PermanentStoragePoolList* psp);
     PermanentStoragePoolList* getPermanentStoragePoolList();
+
+    void setChainAnalyzer(ChainAnalyzer* analyzer);
+    ChainAnalyzer* getChainAnalyzer();
 
     void reset();
 };

--- a/src/BitcoinRpcServer.cpp
+++ b/src/BitcoinRpcServer.cpp
@@ -385,6 +385,204 @@ void BitcoinRpcServer::defineMethods() {
                         //send modified params to wallet
                         return AppMain::GetInstance()->getDigiByteCore()->sendcommand("sendtoaddress", newParams);
                     }},
+            Method{
+                    /**
+                     * Returns a list of utxos for the wallet or provided addresses
+                     *  params[0] - min confirms(optional default 1)
+                     *  params[1] - max confirms(optional default infinity)
+                     *  params[2] - address list(optional all wallet addresses)
+                     *  params[3] - include unsafe(optional - always true no matter what is put in here)
+                     *  params[4] - query options(optional object)
+                     *     {
+                     *       "minimumAmount": amount,       (numeric or string, optional, default=0) Minimum value of **EACH** UTXO in DGB
+                     *       "maximumAmount": amount,       (numeric or string, optional, default=unlimited) Maximum value of **EACH** UTXO in DGB
+                     *       "maximumCount": n,             (numeric, optional, default=unlimited) Maximum number of UTXOs
+                     *       "minimumSumAmount": amount,    (numeric or string, optional, default=unlimited) Minimum sum value of all UTXOs in DGB(stops processing once reached will still return what is found if not reached)
+                     *       "includeAsset": index,         (numeric, bool, or string, default=true) if as string returns only asset utxo with that assetId,
+                     *                                                                               if as integer returns only asset utxo with that assetIndex(faster),
+                     *                                                                               if true returns all utxo
+                     *                                                                               if false returns only funds utxos
+                     *       "detailedAssetData": bool      (bool, optional=false) if true includes detailed asset data.  if false use getassetdata to get
+                     *     }
+                     *
+                     *
+                     * if addresses provided that are not part of wallet it will only return asset utxo unless storenonassetutxo is true                     *
+                     */
+                    .name = "listunspent",
+                    .func = [this](const Json::Value& params) -> Value {
+                        if (params.size() >5) {
+                            throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+                        }
+
+                        //get min confirms default is 1
+                        unsigned int minConfirm=1;
+                        if (params.size()>0) {
+                            if (params[0].isUInt()) {
+                                minConfirm = params[0].asUInt();
+                            } else if (!params[0].isNull()) {
+                                throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+                            }
+                        }
+
+                        //get max confirms default is infinity
+                        unsigned int maxConfirm=std::numeric_limits<unsigned int>::max();
+                        if (params.size()>1) {
+                            if (params[1].isUInt()) {
+                                maxConfirm = params[1].asUInt();
+                            } else if (!params[1].isNull()) {
+                                throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+                            }
+                        }
+
+                        //get addresses
+                        vector<string> addresses;
+                        if ((params.size()>2)&&(!params[2].isNull())) {
+                            if (!params[2].isArray()) throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+
+                            //use provided list
+                            for (const auto& address: params[2]) {
+                                addresses.emplace_back(address.asString());
+                            }
+                        } else {
+                            //get list from wallet
+                            DigiByteCore* dgb=AppMain::GetInstance()->getDigiByteCore();
+                            auto labels=dgb->listlabels();
+                            for (const auto& label: labels) {
+                                auto addressList=dgb->getaddressesbylabel(label);
+                                for (const auto& address: addressList) {
+                                    addresses.emplace_back(address);
+                                }
+                            }
+                        }
+
+                        //get query options
+                        uint64_t minAmount=0;
+                        uint64_t maxAmount=std::numeric_limits<uint64_t>::max();
+                        unsigned int maxCount=std::numeric_limits<unsigned int>::max();
+                        double minSumAmount=INFINITY;
+                        bool returnDigiAssets=true;
+                        uint64_t restrictDigiAssetIndex=0;
+                        string restrictDigiAsset;
+                        bool detailedAssetData=false;
+                        if (params.size()==5) {
+                            if (!params[4].isObject()) throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+
+                            if (params[4].isMember("minimumAmount")) {
+                                if (params[4]["minimumAmount"].isDouble()) {
+                                    minAmount=params[4]["minimumAmount"].asDouble();//todo convert to sats
+                                } else {
+                                    throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+                                }
+                            }
+
+                            if (params[4].isMember("maximumAmount")) {
+                                if (params[4]["maximumAmount"].isDouble()) {
+                                    maxAmount=params[4]["maximumAmount"].asDouble();//todo convert to sats
+                                } else {
+                                    throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+                                }
+                                if (maxAmount<minAmount) throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+                            }
+
+                            if (params[4].isMember("minimumSumAmount")) {
+                                if (params[4]["minimumSumAmount"].isDouble()) {
+                                    minSumAmount=params[4]["minimumSumAmount"].asDouble();
+                                } else {
+                                    throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+                                }
+                            }
+
+                            if (params[4].isMember("includeAsset")) {
+                                if (params[4]["includeAsset"].isUInt64()) {
+                                    restrictDigiAssetIndex=params[4]["includeAsset"].asUInt64();
+                                } else if (params[4]["includeAsset"].isString()) {
+                                    restrictDigiAsset = params[4]["includeAsset"].asString();
+                                } else if (params[4]["includeAsset"].isBool()) {
+                                    returnDigiAssets = params[4]["includeAsset"].asBool();
+                                } else {
+                                    throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+                                }
+                            }
+
+                            if (params[4].isMember("detailedAssetData")) {
+                                if (!params[4]["detailedAssetData"].isBool()) throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+                                detailedAssetData = params[4]["detailedAssetData"].asBool();
+                            }
+                        }
+
+                        //get desired utxos
+                        std::vector<AssetUTXO> utxos;
+                        Database* db=AppMain::GetInstance()->getDatabase();
+                        for (const auto& address: addresses) {
+                            auto addressUTXOs=db->getAddressUTXOs(address,minConfirm,maxConfirm);
+
+                            //filter out undesired utxos
+                            for (const auto& utxo : addressUTXOs) {
+
+                                // Check if the UTXO meets the minimum and maximum amount criteria
+                                if (utxo.assets.empty()) {
+
+                                    //if DigiByte UTXO check balance in requested range
+                                    if (utxo.digibyte < minAmount || utxo.digibyte > maxAmount) {
+                                        continue; // Skip UTXOs outside the desired amount range
+                                    }
+
+                                } else if (returnDigiAssets) {
+
+                                    //is an asset utxo and returning at least some asset utxo
+                                    bool assetMatchFound = false;
+                                    for (const auto& asset : utxo.assets) {
+                                        if (!restrictDigiAsset.empty()) {
+
+                                            //match based on assetId
+                                            if (asset.getAssetId() == restrictDigiAsset) {
+                                                assetMatchFound = true;
+                                                break;
+                                            }
+
+                                        } else if (restrictDigiAssetIndex != 0) {
+
+                                            //match based on assetIndex
+                                            if (asset.getAssetIndex() == restrictDigiAssetIndex) {
+                                                assetMatchFound = true;
+                                                break;
+                                            }
+
+                                        } else {
+
+                                            //what asset not filtered
+                                            assetMatchFound = true;
+
+                                        }
+                                    }
+                                    if (!assetMatchFound) continue;
+
+                                } else {
+
+                                    //digiasset utxo but not wanting digiasset utxos
+                                    continue;
+
+                                }
+
+                                // Add the UTXO to the list if it passed all filters
+                                utxos.push_back(utxo);
+
+                                // Check if we've collected enough UTXOs to meet the 'maximumCount' or 'minimumSumAmount' criteria
+                                if (utxos.size() >= maxCount) goto end_loop;
+                                double totalAmount = std::accumulate(utxos.begin(), utxos.end(), 0.0,
+                                                                     [](double sum, const AssetUTXO& utxo) { return sum + utxo.digibyte; });
+                                if (totalAmount >= minSumAmount) goto end_loop;
+                            }
+                        }
+
+                        //convert results to json
+                        end_loop:
+                        Json::Value result=Json::arrayValue;
+                        for (const auto& utxo: utxos) {
+                            result.append(utxo.toJSON(!detailedAssetData));
+                        }
+                        return result;
+                    }},
 
 
 

--- a/src/BitcoinRpcServer.cpp
+++ b/src/BitcoinRpcServer.cpp
@@ -957,7 +957,15 @@ void BitcoinRpcServer::defineMethods() {
                         if (params.size() != 1) throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
 
                         // Construct the filename from the provided key
-                        std::string filename = "stream/" + params[0].asString() + ".json";
+                        string key;
+                        if (params[0].isInt()) {
+                            key= to_string(params[0].asInt());
+                        } else if (params[0].isString()){
+                            key = params[0].asString();
+                        } else {
+                            throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+                        }
+                        std::string filename = "stream/" + key + ".json";
 
                         // Check if the file exists
                         if (!utils::fileExists(filename)) {

--- a/src/BitcoinRpcServer.cpp
+++ b/src/BitcoinRpcServer.cpp
@@ -931,12 +931,16 @@ void BitcoinRpcServer::defineMethods() {
                         }
 
                         //add to que
-                        string key = params[0].asString();
+                        string key;
+                        if (params[0].isInt()) {
+                            key= to_string(params[0].asInt());
+                        } else if (params[0].isString()){
+                            key = params[0].asString();
+                        } else {
+                            throw DigiByteException(RPC_INVALID_PARAMS, "Invalid params");
+                        }
                         _taskQueue.enqueue(key);
                         return _taskQueue.length();
-
-                        // Return a message indicating the operation is in progress
-                        return {true};
                     }},
             Method{
                     /**
@@ -957,7 +961,7 @@ void BitcoinRpcServer::defineMethods() {
 
                         // Check if the file exists
                         if (!utils::fileExists(filename)) {
-                            return Json::Value(false); // File does not exist
+                            return {false}; // File does not exist
                         }
 
                         // Open and read the file
@@ -970,7 +974,7 @@ void BitcoinRpcServer::defineMethods() {
                         } else {
                             // If the file exists but cannot be opened, return false
                             // This could indicate a permissions issue or a transient file system error
-                            return Json::Value(false);
+                            return {false};
                         }
                     }}};
 }

--- a/src/BitcoinRpcServer.h
+++ b/src/BitcoinRpcServer.h
@@ -23,6 +23,7 @@
 #include <jsonrpccpp/server/connectors/httpserver.h>
 #include "DigiByteCore.h"
 #include "ChainAnalyzer.h"
+#include "UniqueTaskQueue.h"
 
 using namespace std;
 using namespace jsonrpc;
@@ -34,6 +35,9 @@ struct Method {
 };
 
 class BitcoinRpcServer {
+    UniqueTaskQueue _taskQueue;
+    std::atomic<bool> _processingThreadStarted{false};
+
     boost::asio::io_service _io{};
     tcp::acceptor _acceptor{_io};
     std::string _username;

--- a/src/BitcoinRpcServer.h
+++ b/src/BitcoinRpcServer.h
@@ -34,9 +34,6 @@ struct Method {
 };
 
 class BitcoinRpcServer {
-    DigiByteCore* _api;
-    ChainAnalyzer* _analyzer;
-
     boost::asio::io_service _io{};
     tcp::acceptor _acceptor{_io};
     std::string _username;
@@ -58,7 +55,7 @@ class BitcoinRpcServer {
     bool basicAuth(const std::string& header);
     static std::string getHeader(const std::string& headers, const std::string& wantedHeader);
 public:
-    BitcoinRpcServer(DigiByteCore& api, ChainAnalyzer& analyzer, const std::string& fileName = "config.cfg");
+    BitcoinRpcServer(const std::string& fileName = "config.cfg");
 
     void start();
     unsigned int getPort();

--- a/src/Blob.cpp
+++ b/src/Blob.cpp
@@ -51,7 +51,7 @@ Blob::~Blob() {
 constexpr char hexmap[] = {'0', '1', '2', '3', '4', '5', '6', '7',
                            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
-std::string Blob::toHex() {
+std::string Blob::toHex() const {
     std::string s(_length * 2, ' ');
     for (size_t i = 0; i < _length; ++i) {
         s[2 * i] = hexmap[(_data[i] & 0xF0) >> 4];
@@ -60,15 +60,15 @@ std::string Blob::toHex() {
     return s;
 }
 
-unsigned char* Blob::data() {
+unsigned char* Blob::data() const {
     return _data;
 }
 
-size_t Blob::length() {
+size_t Blob::length() const {
     return _length;
 }
 
-std::vector<uint8_t> Blob::vector() {
+std::vector<uint8_t> Blob::vector() const {
     std::vector<uint8_t> result(_length);
     memcpy(&result[0], &_data[0], _length);
     return result;
@@ -81,4 +81,31 @@ Blob::Blob(const std::vector<uint8_t>& data) {
     for (size_t i = 0; i < data.size(); i++) {
         _data[i] = data[i];
     }
+}
+
+Blob::Blob(const Blob& other) : _data(nullptr), _length(0) {
+    if (other._length > 0) {
+        _data = (unsigned char*)malloc(other._length);
+        if (_data == nullptr) throw std::bad_alloc();
+        memcpy(_data, other._data, other._length);
+        _length = other._length;
+    }
+}
+
+Blob& Blob::operator=(const Blob& other) {
+    if (this != &other) { // Protect against self-assignment
+        // Free the existing resource.
+        free(_data);
+
+        _data = nullptr;
+        _length = 0;
+
+        if (other._length > 0) {
+            _data = (unsigned char*)malloc(other._length);
+            if (_data == nullptr) throw std::bad_alloc();
+            memcpy(_data, other._data, other._length);
+            _length = other._length;
+        }
+    }
+    return *this;
 }

--- a/src/Blob.h
+++ b/src/Blob.h
@@ -6,6 +6,7 @@
 #define DIGIBYTECORE_BLOB_H
 
 
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -15,10 +16,26 @@ public:
     explicit Blob(const std::vector<uint8_t>& data);
     explicit Blob(const std::string& hex);
     ~Blob();
-    std::string toHex();
-    unsigned char* data();
-    std::vector<uint8_t> vector();
-    size_t length();
+    std::string toHex() const;
+    unsigned char* data() const;
+    std::vector<uint8_t> vector() const;
+    size_t length() const;
+
+    Blob(const Blob& other);
+    Blob& operator=(const Blob& other);
+
+
+    bool operator==(const Blob& b) const {
+        if (b._length != _length) return false;
+        if (_data != b._data) {
+            return memcmp(_data, b._data, _length) == 0;
+        }
+        return true;
+    }
+
+    bool operator!=(const Blob& b) const {
+        return !(*this == b);
+    }
 
 private:
     unsigned char* _data;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,7 @@ set(HEADER_FILES
         AppMain.h
         CurlHandler.h
         Version.h
+        OldStream.h
         )
 
 set(SOURCE_FILES
@@ -82,6 +83,7 @@ set(SOURCE_FILES
         PermanentStoragePool/pools/local.cpp
         AppMain.cpp
         CurlHandler.cpp
+        OldStream.cpp
         )
 
 add_executable(digiasset_core main.cpp ${SOURCE_FILES} ${HEADER_FILES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ set(HEADER_FILES
         CurlHandler.h
         Version.h
         OldStream.h
+        UniqueTaskQueue.h
         )
 
 set(SOURCE_FILES
@@ -84,6 +85,7 @@ set(SOURCE_FILES
         AppMain.cpp
         CurlHandler.cpp
         OldStream.cpp
+        UniqueTaskQueue.cpp
         )
 
 add_executable(digiasset_core main.cpp ${SOURCE_FILES} ${HEADER_FILES})

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -1262,6 +1262,7 @@ std::vector<AssetUTXO> Database::getAddressUTXOs(const string& address) {
                 entry.digibyte = 0;
                 entry.assets = {};
             }
+            lastTxid=txid;
 
             //add current row data
             if (assetIndex == 1) {

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -129,24 +129,9 @@ void Database::buildTables(unsigned int dbVersionNumber) {
 
             //Define what is changed from version 4 to version 5
             [&]() {
-                //todo this upgrade is unspported also but leaving in as stop gap while servers compute other database changes
-                char* zErrMsg = nullptr;
-                int rc;
-
-                //add column to flag is issuance
-                const char* sql1 =
-                        //chain data tables
-                        "BEGIN TRANSACTION;"
-                        "ALTER TABLE utxos ADD COLUMN issuance INTEGER;"
-                        "ALTER TABLE utxos ADD COLUMN spentTXID BLOB DEFAULT null;"
-                        "UPDATE `flags` SET `value`=5 WHERE `key`='dbVersion';"
-                        "COMMIT";
-                rc = sqlite3_exec(_db, sql1, Database::defaultCallback, nullptr, &zErrMsg);
-                skipUpToVersion = 4; //tell not to execute steps until version 4 to 5 transition
-                if (rc != SQLITE_OK) {
-                    sqlite3_free(zErrMsg);
-                    throw exceptionFailedToCreateTable();
-                }
+                Log* log=Log::GetInstance();
+                log->addMessage("Unsupported database version.",Log::CRITICAL);
+                throw runtime_error("Unsupported database version.");
             }
 
             /*  To modify table structure place a comma after the last } above and then place the bellow code.

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -11,12 +11,10 @@
 #include "Log.h"
 #include "PermanentStoragePool/PermanentStoragePoolList.h"
 #include "utils.h"
-#include <cmath>
-#include <cstring>
+#include <algorithm>
 #include <mutex>
 #include <sqlite3.h>
 #include <stdio.h>
-#include <sys/stat.h>
 
 using namespace std;
 
@@ -49,7 +47,7 @@ void Database::buildTables(unsigned int dbVersionNumber) {
 
             //Define Version 4 table setup
             [&]() {
-                char* zErrMsg = 0;
+                char* zErrMsg = nullptr;
                 int rc;
                 const char* sql =
                         //chain data tables
@@ -72,12 +70,12 @@ void Database::buildTables(unsigned int dbVersionNumber) {
                         "INSERT INTO \"flags\" VALUES (\"wasPrunedUTXOHistory\",-1);"
                         "INSERT INTO \"flags\" VALUES (\"wasPrunedVoteHistory\",-1);"
                         "INSERT INTO \"flags\" VALUES (\"wasPrunedNonAssetUTXOHistory\",0);"
-                        "INSERT INTO \"flags\" VALUES (\"dbVersion\",4);"
+                        "INSERT INTO \"flags\" VALUES (\"dbVersion\",5);"
 
                         "CREATE TABLE \"kyc\" (\"address\" TEXT NOT NULL, \"country\" TEXT NOT NULL, \"name\" TEXT NOT NULL, \"hash\" BLOB NOT NULL, \"height\" INTEGER NOT NULL, \"revoked\" INTEGER, PRIMARY KEY(\"address\"));"
                         "CREATE INDEX kyc_height_index ON kyc(height);"
 
-                        "CREATE TABLE \"utxos\" (\"address\" TEXT NOT NULL, \"txid\" BLOB NOT NULL, \"vout\" INTEGER NOT NULL, \"aout\" INTEGER, \"assetIndex\" Integer NOT NULL, \"amount\" INTEGER NOT NULL, \"heightCreated\" INTEGER NOT NULL, \"heightDestroyed\" INTEGER, PRIMARY KEY(\"address\",\"txid\",\"vout\",\"aout\"));"
+                        "CREATE TABLE \"utxos\" (\"address\" TEXT NOT NULL, \"txid\" BLOB NOT NULL, \"vout\" INTEGER NOT NULL, \"aout\" INTEGER, \"assetIndex\" Integer NOT NULL, \"amount\" INTEGER NOT NULL, \"heightCreated\" INTEGER NOT NULL, \"heightDestroyed\" INTEGER, issuance INTEGER, spentTXID BLOB DEFAULT null, PRIMARY KEY(\"address\",\"txid\",\"vout\",\"aout\"));"
 
                         "CREATE TABLE \"votes\" (\"assetIndex\" Integer NOT NULL, \"address\" TEXT NOT NULL, \"height\" INTEGER NOT NULL, \"count\" INTEGER NOT NULL, PRIMARY KEY(\"assetIndex\",\"address\",\"height\"));"
 
@@ -96,8 +94,8 @@ void Database::buildTables(unsigned int dbVersionNumber) {
                         "INSERT INTO \"domainsMasters\" VALUES (\"Ua7Bd7UVtrzavSHhpHxHZ2nzS2hGaHXRMT9sqy\",true);"
 
                         "COMMIT";
-                rc = sqlite3_exec(_db, sql, Database::defaultCallback, 0, &zErrMsg);
-                skipUpToVersion = 4; //tell not to execute steps until version 4 to 5 transition
+                rc = sqlite3_exec(_db, sql, Database::defaultCallback, nullptr, &zErrMsg);
+                skipUpToVersion = 5; //tell not to execute steps until version 5 to 6 transition
                 if (rc != SQLITE_OK) {
                     sqlite3_free(zErrMsg);
                     throw exceptionFailedToCreateTable();
@@ -126,6 +124,29 @@ void Database::buildTables(unsigned int dbVersionNumber) {
                 Log* log=Log::GetInstance();
                 log->addMessage("Unsupported database version.",Log::CRITICAL);
                 throw runtime_error("Unsupported database version.");
+            },
+
+
+            //Define what is changed from version 4 to version 5
+            [&]() {
+                //todo this upgrade is unspported also but leaving in as stop gap while servers compute other database changes
+                char* zErrMsg = nullptr;
+                int rc;
+
+                //add column to flag is issuance
+                const char* sql1 =
+                        //chain data tables
+                        "BEGIN TRANSACTION;"
+                        "ALTER TABLE utxos ADD COLUMN issuance INTEGER;"
+                        "ALTER TABLE utxos ADD COLUMN spentTXID BLOB DEFAULT null;"
+                        "UPDATE `flags` SET `value`=5 WHERE `key`='dbVersion';"
+                        "COMMIT";
+                rc = sqlite3_exec(_db, sql1, Database::defaultCallback, nullptr, &zErrMsg);
+                skipUpToVersion = 4; //tell not to execute steps until version 4 to 5 transition
+                if (rc != SQLITE_OK) {
+                    sqlite3_free(zErrMsg);
+                    throw exceptionFailedToCreateTable();
+                }
             }
 
             /*  To modify table structure place a comma after the last } above and then place the bellow code.
@@ -164,313 +185,258 @@ void Database::buildTables(unsigned int dbVersionNumber) {
  */
 void Database::initializeClassValues() {
     //statement to find a flag value
-    const char* sql10 = "SELECT value FROM flags WHERE key LIKE ?;";
-    int rc = sqlite3_prepare_v2(_db, sql10, strlen(sql10), &_stmtCheckFlag, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtCheckFlag.prepare(_db,"SELECT value FROM flags WHERE key LIKE ?;");
 
     //statement to set a flag value
-    const char* sql11 = "UPDATE flags SET value=? WHERE key LIKE ?;";
-    rc = sqlite3_prepare_v2(_db, sql11, strlen(sql11), &_stmtSetFlag, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtSetFlag.prepare(_db,"UPDATE flags SET value=? WHERE key LIKE ?;");
 
 
     //statement to get block height
-    const char* sql20 = "SELECT height FROM blocks ORDER BY height DESC LIMIT 1;";
-    rc = sqlite3_prepare_v2(_db, sql20, strlen(sql20), &_stmtGetBlockHeight, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetBlockHeight.prepare(_db,"SELECT height FROM blocks ORDER BY height DESC LIMIT 1;");
 
     //statement to set block height
-    const char* sql21 = "INSERT INTO blocks VALUES (?,?,?,?,?);";
-    rc = sqlite3_prepare_v2(_db, sql21, strlen(sql21), &_stmtInsertBlock, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtInsertBlock.prepare(_db,"INSERT INTO blocks VALUES (?,?,?,?,?);");
 
     //statement to get block hash
-    const char* sql22 = "SELECT hash FROM blocks WHERE height=? LIMIT 1;";
-    rc = sqlite3_prepare_v2(_db, sql22, strlen(sql22), &_stmtGetBlockHash, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetBlockHash.prepare(_db,"SELECT hash FROM blocks WHERE height=? LIMIT 1;");
 
     //second half of prune statement.  removes blocks from list that it is no longer possible to roll back to
-    const char* sql23 = "DELETE FROM blocks where height<?;";
-    rc = sqlite3_prepare_v2(_db, sql23, strlen(sql23), &_stmtRemoveNonReachable, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtRemoveNonReachable.prepare(_db,"DELETE FROM blocks where height<?;");
 
 
 
 
     //statement to create UTXO
-    const char* sql40 = "INSERT INTO utxos VALUES (?,?,?,?,?,?,?,NULL);";
-    rc = sqlite3_prepare_v2(_db, sql40, strlen(sql40), &_stmtCreateUTXO, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtCreateUTXO.prepare(_db,"INSERT INTO utxos (address,txid,vout,aout,assetIndex,amount,heightCreated,issuance)  VALUES (?,?,?,?,?,?,?,?);");
 
     //statement to spend UTXO
-    const char* sql42 = "UPDATE utxos SET heightDestroyed=? WHERE txid=? AND vout=?;";
-    rc = sqlite3_prepare_v2(_db, sql42, strlen(sql42), &_stmtSpendUTXO, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtSpendUTXO.prepare(_db,"UPDATE utxos SET heightDestroyed=?, spentTXID=? WHERE txid=? AND vout=?;");
 
     //statement to get spending address from UTXO
-    const char* sql43 = "SELECT address FROM utxos WHERE txid=? AND vout=?";
-    rc = sqlite3_prepare_v2(_db, sql43, strlen(sql43), &_stmtGetSpendingAddress, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetSpendingAddress.prepare(_db,"SELECT address FROM utxos WHERE txid=? AND vout=?");
 
     //statement to prune utxos
-    const char* sql44 = "DELETE FROM utxos WHERE heightDestroyed<?;";
-    rc = sqlite3_prepare_v2(_db, sql44, strlen(sql44), &_stmtPruneUTXOs, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtPruneUTXOs.prepare(_db,"DELETE FROM utxos WHERE heightDestroyed<?;");
 
     //statement to get funds on a UTXO
-    const char* sql45 = "SELECT address,aout,assetIndex,amount FROM utxos WHERE txid=? AND vout=? ORDER BY aout ASC;";
-    rc = sqlite3_prepare_v2(_db, sql45, strlen(sql45), &_stmtGetAssetUTXO, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetAssetUTXO.prepare(_db,"SELECT address,aout,assetIndex,amount FROM utxos WHERE txid=? AND vout=? ORDER BY aout ASC;");
 
     //statement to get asset holders
-    const char* sql46 = "SELECT address,SUM(amount) FROM utxos WHERE assetIndex=? AND heightDestroyed IS NULL GROUP BY address;";
-    rc = sqlite3_prepare_v2(_db, sql46, strlen(sql46), &_stmtGetAssetHolders, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetAssetHolders.prepare(_db,"SELECT address,SUM(amount) FROM utxos WHERE assetIndex=? AND heightDestroyed IS NULL GROUP BY address;");
 
     //statement to get all assetIndexs on a specific utxo
-    const char* sql47 = "SELECT assetIndex FROM utxos WHERE txid=? AND vout=? AND aout IS NOT NULL;";
-    rc = sqlite3_prepare_v2(_db, sql47, strlen(sql47), &_stmtGetAssetIndexOnUTXO, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetAssetIndexOnUTXO.prepare(_db,"SELECT assetIndex FROM utxos WHERE txid=? AND vout=? AND aout IS NOT NULL;");
 
     //statement to get permanent storage paid on a specific transaction
-    const char* sql48 = "SELECT amount,heightCreated FROM utxos where txid=? and address=? and aout is null;";
-    rc = sqlite3_prepare_v2(_db, sql48, strlen(sql48), &_stmtGetPermanentPaid, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetPermanentPaid.prepare(_db,"SELECT amount,heightCreated FROM utxos where txid=? and address=? and aout is null;");
 
     //statement to get number of assets that exist
-    const char* sql49a = "SELECT sum(amount) FROM utxos where assetIndex=? and heightDestroyed is null;";
-    rc = sqlite3_prepare_v2(_db, sql49a, strlen(sql49a), &_stmtGetTotalAssetCounta, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
-    const char* sql49b = "SELECT sum(u.amount) as totalAmount\n"
-                         "FROM utxos u\n"
-                         "JOIN assets a ON u.assetIndex = a.assetIndex\n"
-                         "WHERE a.assetId = ? AND u.heightDestroyed IS NULL;";
-    rc = sqlite3_prepare_v2(_db, sql49b, strlen(sql49b), &_stmtGetTotalAssetCountb, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetTotalAssetCounta.prepare(_db,"SELECT sum(amount) FROM utxos where assetIndex=? and heightDestroyed is null;");
+    _stmtGetTotalAssetCountb.prepare(_db,"SELECT sum(u.amount) as totalAmount\n"
+                                         "FROM utxos u\n"
+                                         "JOIN assets a ON u.assetIndex = a.assetIndex\n"
+                                         "WHERE a.assetId = ? AND u.heightDestroyed IS NULL;");
+
+    //statement to get number of assets that exist
+    _stmtGetOriginalAssetCounta.prepare(_db,"SELECT sum(amount) FROM utxos where assetIndex=? and issuance=1;");
+    _stmtGetOriginalAssetCountb.prepare(_db,"SELECT sum(u.amount) as totalAmount\n"
+                                            "FROM utxos u\n"
+                                            "JOIN assets a ON u.assetIndex = a.assetIndex\n"
+                                            "WHERE a.assetId = ? AND u.issuance=1;");
+
+    //statement to get tx history
+    _stmtGetAssetTxHistorya.prepare(_db,"SELECT txid\n"
+                                         "FROM (\n"
+                                         //"    -- Select txids where the asset was received\n"
+                                         "    SELECT u.txid, u.heightCreated AS height\n"
+                                         "    FROM utxos u\n"
+                                         "    WHERE u.assetIndex = ?\n"
+                                         "    UNION\n"
+                                         //"    -- Select txids where the asset was spent\n"
+                                         "    SELECT u.spentTXID AS txid, u.heightDestroyed AS height\n"
+                                         "    FROM utxos u\n"
+                                         "    WHERE u.assetIndex = ? AND u.spentTXID IS NOT NULL\n"
+                                         "    UNION\n"
+                                         //"    -- find txid that created the asset"
+                                         "    SELECT u2.spentTXID AS txid, u2.heightCreated AS height\n"
+                                         "    FROM utxos u1\n"
+                                         "    JOIN utxos u2 ON u1.txid = u2.spentTXID\n"
+                                         "    WHERE u1.assetIndex = ? AND u1.issuance = 1 AND u2.spentTXID IS NOT NULL\n"
+                                         ") GROUP BY txid\n"
+                                         "ORDER BY height ASC;");
+    _stmtGetAssetTxHistoryb.prepare(_db,"SELECT txid\n"
+                                        "FROM (\n"
+                                        //"    -- Select txids where the asset was received\n"
+                                        "    SELECT u.txid, u.heightCreated AS height\n"
+                                        "    FROM utxos u\n"
+                                        "    JOIN assets a ON u.assetIndex = a.assetIndex\n"
+                                        "    WHERE a.assetId = ?\n"
+                                        "    UNION\n"
+                                        //"    -- Select txids where the asset was spent\n"
+                                        "    SELECT u.spentTXID AS txid, u.heightDestroyed AS height\n"
+                                        "    FROM utxos u\n"
+                                        "    JOIN assets a ON u.assetIndex = a.assetIndex\n"
+                                        "    WHERE a.assetId = ? AND u.spentTXID IS NOT NULL\n"
+                                        "    UNION\n"
+                                        //"    -- find txid that created the asset"
+                                        "    SELECT u2.spentTXID AS txid, u2.heightCreated AS height\n"
+                                        "    FROM utxos u1\n"
+                                        "    JOIN utxos u2 ON u1.txid = u2.spentTXID\n"
+                                        "    JOIN assets a ON u1.assetIndex = a.assetIndex\n"
+                                        "    WHERE a.assetId = ? AND u1.issuance = 1 AND u2.spentTXID IS NOT NULL\n"
+                                        ") GROUP BY txid\n"
+                                        "ORDER BY height ASC;");
+    _stmtGetAddressTxHistory.prepare(_db,"SELECT tx "
+                                         "FROM ( "
+                                             "SELECT txid AS tx, heightCreated AS height "
+                                             "FROM utxos "
+                                             "WHERE address=? "
+                                             "UNION "
+                                             "SELECT spentTXID AS tx, heightDestroyed AS height "
+                                             "FROM utxos "
+                                             "WHERE address=? AND spentTXID IS NOT NULL "
+                                         ") "
+                                         "ORDER BY height ASC;");
+
+    //statement to get valid utxos for a given address
+    _stmtGetValidUTXO.prepare(_db,"SELECT `txid`,`vout`,`aout`,`assetIndex`,`amount` FROM utxos WHERE heightDestroyed IS NULL AND address=? ORDER BY txid ASC, vout ASC, aout ASC;");
+
 
 
 
     //statement to check if exchange watch address
-    const char* sql50 = "SELECT address FROM exchangeWatch WHERE address=?;";
-    rc = sqlite3_prepare_v2(_db, sql50, strlen(sql50), &_stmtIsWatchAddress, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtIsWatchAddress.prepare(_db,"SELECT address FROM exchangeWatch WHERE address=?;");
 
     //statement to add exchange watch address
-    const char* sql51 = "INSERT INTO exchangeWatch VALUES (?);";
-    rc = sqlite3_prepare_v2(_db, sql51, strlen(sql51), &_stmtAddWatchAddress, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtAddWatchAddress.prepare(_db,"INSERT INTO exchangeWatch VALUES (?);");
 
 
     //statement to insert new exchange rate
-    const char* sql60 = "INSERT INTO exchange VALUES (?,?,?,?);";
-    rc = sqlite3_prepare_v2(_db, sql60, strlen(sql60), &_stmtAddExchangeRate, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtAddExchangeRate.prepare(_db,"INSERT INTO exchange VALUES (?,?,?,?);");
 
     //statement to get current exchange rates(all rates)
-    const char* sql61 = "WITH cte AS (\n"
-                        "  SELECT *, ROW_NUMBER() OVER (PARTITION BY [address], [index] ORDER BY height DESC) AS row_number\n"
-                        "  FROM exchange\n"
-                        "  WHERE height < ?\n"
-                        ")\n"
-                        "SELECT [height], [address], [index], [value]\n"
-                        "FROM cte\n"
-                        "WHERE row_number = 1;";
-    rc = sqlite3_prepare_v2(_db, sql61, strlen(sql61), &_stmtExchangeRatesAtHeight, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtExchangeRatesAtHeight.prepare(_db,"WITH cte AS (\n"
+                                            "  SELECT *, ROW_NUMBER() OVER (PARTITION BY [address], [index] ORDER BY height DESC) AS row_number\n"
+                                            "  FROM exchange\n"
+                                            "  WHERE height < ?\n"
+                                            ")\n"
+                                            "SELECT [height], [address], [index], [value]\n"
+                                            "FROM cte\n"
+                                            "WHERE row_number = 1;");
 
     //statement to delete exchange rates bellow a specific height
-    const char* sql62 = "DELETE FROM exchange WHERE height<?;";
-    rc = sqlite3_prepare_v2(_db, sql62, strlen(sql62), &_stmtPruneExchangeRate, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtPruneExchangeRate.prepare(_db,"DELETE FROM exchange WHERE height<?;");
 
     //statement to get accepted exchange rate at a specific height
-    const char* sql63 = "SELECT value, height FROM exchange WHERE height<? AND address=? AND [index]=? ORDER BY height DESC;";
-    rc = sqlite3_prepare_v2(_db, sql63, strlen(sql63), &_stmtGetValidExchangeRate, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetValidExchangeRate.prepare(_db,"SELECT value, height FROM exchange WHERE height<? AND address=? AND [index]=? ORDER BY height DESC;");
 
     //statement to get current exchange rate(1 rate)
-    const char* sql64 = "SELECT value FROM exchange WHERE address=? AND [index]=? ORDER BY height DESC LIMIT 1;";
-    rc = sqlite3_prepare_v2(_db, sql64, strlen(sql64), &_stmtGetCurrentExchangeRate, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetCurrentExchangeRate.prepare(_db,"SELECT value FROM exchange WHERE address=? AND [index]=? ORDER BY height DESC LIMIT 1;");
 
 
     //statement to insert new kyc record
-    const char* sql70 = "INSERT OR IGNORE INTO kyc VALUES (?,?,?,?,?,NULL);";
-    rc = sqlite3_prepare_v2(_db, sql70, strlen(sql70), &_stmtAddKYC, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtAddKYC.prepare(_db,"INSERT OR IGNORE INTO kyc VALUES (?,?,?,?,?,NULL);");
 
     //statement to revoke kyc record
-    const char* sql71 = "UPDATE kyc SET revoked=? WHERE address=?;";
-    rc = sqlite3_prepare_v2(_db, sql71, strlen(sql71), &_stmtRevokeKYC, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtRevokeKYC.prepare(_db,"UPDATE kyc SET revoked=? WHERE address=?;");
 
     //statement to revoke kyc record
-    const char* sql72 = "SELECT country,name,hash,height,revoked FROM kyc WHERE address=?;";
-    rc = sqlite3_prepare_v2(_db, sql72, strlen(sql72), &_stmtGetKYC, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetKYC.prepare(_db,"SELECT country,name,hash,height,revoked FROM kyc WHERE address=?;");
 
 
     //statement to get total votes at specific height
-    const char* sql80 = "SELECT assetIndex,address,SUM([count]),MAX([height]) FROM votes WHERE height<10 GROUP BY assetIndex,address;";
-    rc = sqlite3_prepare_v2(_db, sql80, strlen(sql80), &_stmtGetVoteCount, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetVoteCountAtHeight.prepare(_db,"SELECT assetIndex,address,SUM([count]),MAX([height]) FROM votes WHERE height<? GROUP BY assetIndex,address;");
 
     //statement to prune votes
-    const char* sql81 = "DELETE FROM votes WHERE height<?;";
-    rc = sqlite3_prepare_v2(_db, sql81, strlen(sql81), &_stmtPruneVote, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtPruneVote.prepare(_db,"DELETE FROM votes WHERE height<?;");
 
     //statement to record votes
-    const char* sql82 = "INSERT INTO votes (assetIndex, address, height, count) VALUES (?, ?, ?, ?) ON CONFLICT (assetIndex, address, height) DO UPDATE SET count=count+?;";
-    rc = sqlite3_prepare_v2(_db, sql82, strlen(sql82), &_stmtAddVote, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtAddVote.prepare(_db,"INSERT INTO votes (assetIndex, address, height, count) VALUES (?, ?, ?, ?) ON CONFLICT (assetIndex, address, height) DO UPDATE SET count=count+?;");
+
+    //statement to get vote counts for an asset
+    _stmtGetVoteCount.prepare(_db,"SELECT address,SUM([count]) FROM votes WHERE assetIndex=? GROUP BY address;");
 
     //statement to add asset
-    const char* sql90 = "INSERT INTO assets (assetId, issueAddress, cid, rules, heightCreated, heightUpdated, expires) VALUES (?, ?, ?, ?, ?, ?, ?);";
-    rc = sqlite3_prepare_v2(_db, sql90, strlen(sql90), &_stmtAddAsset, nullptr);
-    if (rc != SQLITE_OK) {
-
-        string tempErrorMessage = sqlite3_errmsg(_db);
-        throw exceptionCreatingStatement();
-    }
+    _stmtAddAsset.prepare(_db,"INSERT INTO assets (assetId, issueAddress, cid, rules, heightCreated, heightUpdated, expires) VALUES (?, ?, ?, ?, ?, ?, ?);");
 
     //statement to update asset(aggregable only)
-    const char* sql91 = "UPDATE assets SET heightUpdated=?, cid=?, rules=?, expires=? WHERE assetIndex=?";
-    rc = sqlite3_prepare_v2(_db, sql91, strlen(sql91), &_stmtUpdateAsset, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtUpdateAsset.prepare(_db,"UPDATE assets SET heightUpdated=?, cid=?, rules=?, expires=? WHERE assetIndex=?");
 
-    //statement to get assetIndex(don't use for non aggregable)
-    const char* sql92 = "SELECT assetIndex FROM assets WHERE assetId=?";
-    rc = sqlite3_prepare_v2(_db, sql92, strlen(sql92), &_stmtGetAssetIndex, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    //statement to get assetIndex(don't use for non-aggregable)
+    _stmtGetAssetIndex.prepare(_db,"SELECT assetIndex FROM assets WHERE assetId=?");
 
     //statement to get height created
-    const char* sql93 = "SELECT assetIndex,heightCreated FROM assets WHERE assetId=?";
-    rc = sqlite3_prepare_v2(_db, sql93, strlen(sql93), &_stmtGetHeightAssetCreated, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetHeightAssetCreated.prepare(_db,"SELECT assetIndex,heightCreated FROM assets WHERE assetId=?");
 
     //statement to get asset rules
-    const char* sql94 = "SELECT rules FROM assets WHERE assetId=?";
-    rc = sqlite3_prepare_v2(_db, sql94, strlen(sql94), &_stmtGetAssetRules, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetAssetRules.prepare(_db,"SELECT rules FROM assets WHERE assetId=?");
 
     //statement to get asset
-    const char* sql95 = "SELECT assetId,cid,issueAddress,rules,heightCreated,heightUpdated FROM assets WHERE assetIndex=?";
-    rc = sqlite3_prepare_v2(_db, sql95, strlen(sql95), &_stmtGetAsset, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetAsset.prepare(_db,"SELECT assetId,cid,issueAddress,rules,heightCreated,heightUpdated FROM assets WHERE assetIndex=?");
+
+    //statement to get asset created by an address
+    _stmtGetAssetCreateByAddress.prepare(_db,"SELECT assetIndex FROM assets where issueAddress=? order by assetIndex asc;");
 
 
     //statement for IPFS
-    const char* sql100 = "SELECT jobIndex,sync,cid,extra,callback,maxTime FROM ipfs WHERE pause is NULL AND lock is false ORDER BY jobIndex ASC LIMIT 1;";
-    rc = sqlite3_prepare_v2(_db, sql100, strlen(sql100), &_stmtGetNextIPFSJob, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetNextIPFSJob.prepare(_db,"SELECT jobIndex,sync,cid,extra,callback,maxTime FROM ipfs WHERE pause is NULL AND lock is false ORDER BY jobIndex ASC LIMIT 1;");
 
-    const char* sql101a = "DELETE FROM ipfs WHERE jobIndex=?;";
-    rc = sqlite3_prepare_v2(_db, sql101a, strlen(sql101a), &_stmtClearNextIPFSJob_a, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtClearNextIPFSJob_a.prepare(_db,"DELETE FROM ipfs WHERE jobIndex=?;");
+    _stmtClearNextIPFSJob_b.prepare(_db,"UPDATE ipfs set lock=false WHERE sync=?;");
 
-    const char* sql101b = "UPDATE ipfs set lock=false WHERE sync=?;";
-    rc = sqlite3_prepare_v2(_db, sql101b, strlen(sql101b), &_stmtClearNextIPFSJob_b, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtInsertIPFSJob.prepare(_db,"INSERT INTO ipfs (sync, lock, cid, extra, callback, pause, maxTime) VALUES (?,false,?,?,?,?,?);");
 
-    const char* sql102 = "INSERT INTO ipfs (sync, lock, cid, extra, callback, pause, maxTime) VALUES (?,false,?,?,?,?,?);";
-    rc = sqlite3_prepare_v2(_db, sql102, strlen(sql102), &_stmtInsertIPFSJob, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtSetIPFSPauseSync.prepare(_db,"UPDATE ipfs set pause=?, lock=false WHERE sync=?;");
 
-    const char* sql103 = "UPDATE ipfs set pause=?, lock=false WHERE sync=?;";
-    rc = sqlite3_prepare_v2(_db, sql103, strlen(sql103), &_stmtSetIPFSPauseSync, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtClearIPFSPause.prepare(_db,"UPDATE ipfs set pause=NULL WHERE pause<?;");
 
-    const char* sql104 = "UPDATE ipfs set pause=NULL WHERE pause<?;";
-    rc = sqlite3_prepare_v2(_db, sql104, strlen(sql104), &_stmtClearIPFSPause, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtSetIPFSLockSync.prepare(_db,"UPDATE ipfs set lock=true WHERE sync=?;");
 
-    const char* sql105 = "UPDATE ipfs set lock=true WHERE sync=?;";
-    rc = sqlite3_prepare_v2(_db, sql105, strlen(sql105), &_stmtSetIPFSLockSync, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtSetIPFSPauseJob.prepare(_db,"UPDATE ipfs set pause=?, lock=false WHERE jobIndex=?;");
 
-    const char* sql106 = "UPDATE ipfs set pause=?, lock=false WHERE jobIndex=?;";
-    rc = sqlite3_prepare_v2(_db, sql106, strlen(sql106), &_stmtSetIPFSPauseJob, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtSetIPFSLockJob.prepare(_db,"UPDATE ipfs set lock=true WHERE jobIndex=?;");
 
-    const char* sql107 = "UPDATE ipfs set lock=true WHERE jobIndex=?;";
-    rc = sqlite3_prepare_v2(_db, sql107, strlen(sql107), &_stmtSetIPFSLockJob, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
-
-    const char* sql108 = "SELECT count(*) FROM ipfs;";
-    rc = sqlite3_prepare_v2(_db, sql108, strlen(sql108), &_stmtNumberOfIPFSJobs, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtNumberOfIPFSJobs.prepare(_db,"SELECT count(*) FROM ipfs;");
 
     //DigiByte Domain statements
-    const char* sql110 = "SELECT assetId,revoked FROM domains WHERE domain=?";
-    rc = sqlite3_prepare_v2(_db, sql110, strlen(sql110), &_stmtGetDomainAssetId, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtGetDomainAssetId.prepare(_db,"SELECT assetId,revoked FROM domains WHERE domain=?");
 
-    const char* sql112 = "INSERT INTO domains VALUES (?,?,false);";
-    rc = sqlite3_prepare_v2(_db, sql112, strlen(sql112), &_stmtAddDomain, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtAddDomain.prepare(_db,"INSERT INTO domains VALUES (?,?,false);");
 
-    const char* sql113 = "UPDATE domains SET revoked=true WHERE domain=?;";
-    rc = sqlite3_prepare_v2(_db, sql113, strlen(sql113), &_stmtRevokeDomain, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtRevokeDomain.prepare(_db,"UPDATE domains SET revoked=true WHERE domain=?;");
 
-    const char* sql114a = "UPDATE domainsMasters SET active=false WHERE assetId=?;";
-    rc = sqlite3_prepare_v2(_db, sql114a, strlen(sql114a), &_stmtSetDomainMasterAssetId_a, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
-
-    const char* sql114b = "INSERT INTO domainsMasters VALUES (?,true);";
-    rc = sqlite3_prepare_v2(_db, sql114b, strlen(sql114b), &_stmtSetDomainMasterAssetId_b, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtSetDomainMasterAssetId_a.prepare(_db,"UPDATE domainsMasters SET active=false WHERE assetId=?;");
+    _stmtSetDomainMasterAssetId_b.prepare(_db,"INSERT INTO domainsMasters VALUES (?,true);");
 
     //IPFS Permanent statements
-    const char* sql120 = "INSERT OR IGNORE INTO pspFiles (cid,poolIndex) VALUES (?,?)";
-    rc = sqlite3_prepare_v2(_db, sql120, strlen(sql120), &_stmtInsertPermanent, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtInsertPermanent.prepare(_db,"INSERT OR IGNORE INTO pspFiles (cid,poolIndex) VALUES (?,?)");
 
-    const char* sql120b = "DELETE FROM pspFiles WHERE cid=? AND poolIndex=?";
-    rc = sqlite3_prepare_v2(_db, sql120b, strlen(sql120b), &_stmtDeletePermanent, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtDeletePermanent.prepare(_db,"DELETE FROM pspFiles WHERE cid=? AND poolIndex=?");
 
-    const char* sql120c = "SELECT 1 FROM pspFiles WHERE cid=?";
-    rc = sqlite3_prepare_v2(_db, sql120c, strlen(sql120c), &_stmtIsInPermanent, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtIsInPermanent.prepare(_db,"SELECT 1 FROM pspFiles WHERE cid=?");
 
-    const char* sql121 = "INSERT INTO ipfs (sync, lock, cid, extra, callback, pause, maxTime) SELECT 'pin', 0, cid, '', '', NULL, NULL FROM assets WHERE cid != '';";
-    rc = sqlite3_prepare_v2(_db, sql121, strlen(sql121), &_stmtRepinAssets, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtRepinAssets.prepare(_db,"INSERT INTO ipfs (sync, lock, cid, extra, callback, pause, maxTime) SELECT 'pin', 0, cid, '', '', NULL, NULL FROM assets WHERE cid != '';");
 
-    const char* sql122 = "INSERT INTO ipfs (sync, lock, cid, extra, callback, pause, maxTime) SELECT 'pin', 0, cid, '', '', NULL, NULL FROM pspFiles WHERE \"poolIndex\" = ?;";
-    rc = sqlite3_prepare_v2(_db, sql122, strlen(sql122), &_stmtRepinPermanentSpecific, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtRepinPermanentSpecific.prepare(_db,"INSERT INTO ipfs (sync, lock, cid, extra, callback, pause, maxTime) SELECT 'pin', 0, cid, '', '', NULL, NULL FROM pspFiles WHERE \"poolIndex\" = ?;");
 
-    const char* sql124 = "INSERT OR IGNORE INTO pspAssets (assetIndex,poolIndex) VALUES (?,?);";
-    rc = sqlite3_prepare_v2(_db, sql124, strlen(sql124), &_stmtAddAssetToPool, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtAddAssetToPool.prepare(_db,"INSERT OR IGNORE INTO pspAssets (assetIndex,poolIndex) VALUES (?,?);");
 
-    const char* sql125 = "SELECT COUNT(*) FROM \"pspAssets\" WHERE \"assetIndex\" = ? AND \"poolIndex\" = ?;";
-    rc = sqlite3_prepare_v2(_db, sql125, strlen(sql125), &_stmtIsAssetInPool, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtIsAssetInPool.prepare(_db,"SELECT COUNT(*) FROM \"pspAssets\" WHERE \"assetIndex\" = ? AND \"poolIndex\" = ?;");
 
-    const char* sql125b = "SELECT 1 FROM \"pspAssets\" WHERE \"assetIndex\" = ?;";
-    rc = sqlite3_prepare_v2(_db, sql125b, strlen(sql125b), &_stmtIsAssetInAPool, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtIsAssetInAPool.prepare(_db,"SELECT 1 FROM \"pspAssets\" WHERE \"assetIndex\" = ?;");
 
-    const char* sql131 = "SELECT a.assetIndex, a.cid "
-                         "FROM assets a "
-                         "INNER JOIN pspAssets p ON a.assetIndex = p.assetIndex "
-                         "WHERE a.assetId = ? AND p.poolIndex = ?;";
-    rc = sqlite3_prepare_v2(_db, sql131, strlen(sql131), &_stmtPSPFindBadAsset, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtPSPFindBadAsset.prepare(_db,"SELECT a.assetIndex, a.cid "
+                                     "FROM assets a "
+                                     "INNER JOIN pspAssets p ON a.assetIndex = p.assetIndex "
+                                     "WHERE a.assetId = ? AND p.poolIndex = ?;");
 
-    const char* sql132 = "DELETE FROM pspAssets "
-                         "WHERE assetIndex IN ("
-                         "    SELECT a.assetIndex "
-                         "    FROM assets a "
-                         "    INNER JOIN pspAssets p ON a.assetIndex = p.assetIndex "
-                         "    WHERE a.assetId = ? AND p.poolIndex = ?"
-                         ");";
-    rc = sqlite3_prepare_v2(_db, sql132, strlen(sql132), &_stmtPSPDeleteBadAsset, nullptr);
-    if (rc != SQLITE_OK) throw exceptionCreatingStatement();
+    _stmtPSPDeleteBadAsset.prepare(_db,"DELETE FROM pspAssets "
+                                         "WHERE assetIndex IN ("
+                                         "    SELECT a.assetIndex "
+                                         "    FROM assets a "
+                                         "    INNER JOIN pspAssets p ON a.assetIndex = p.assetIndex "
+                                         "    WHERE a.assetId = ? AND p.poolIndex = ?"
+                                         ");");
 
 
 
@@ -478,7 +444,7 @@ void Database::initializeClassValues() {
     //initialize exchange address watch list
     sqlite3_stmt* stmt1;
     const char* sqlInt10 = "SELECT address FROM exchangeWatch WHERE 1;";
-    rc = sqlite3_prepare_v2(_db, sqlInt10, -1, &stmt1, NULL);
+    int rc = sqlite3_prepare_v2(_db, sqlInt10, -1, &stmt1, nullptr);
     if (rc != SQLITE_OK) throw exceptionCreatingStatement();
     for (;;) {
         rc = executeSqliteStepWithRetry(stmt1);
@@ -498,9 +464,9 @@ void Database::initializeClassValues() {
     sqlite3_finalize(stmt1);
 
     //initialize ipfs(remove all non-permanent jobs and any pauses)
-    char* zErrMsg = 0;
+    char* zErrMsg = nullptr;
     const char* sqlInt11 = "DELETE FROM ipfs WHERE callback LIKE \"_\";UPDATE ipfs SET pause=NULL,lock=0;";
-    rc = sqlite3_exec(_db, sqlInt11, Database::defaultCallback, 0, &zErrMsg);
+    rc = sqlite3_exec(_db, sqlInt11, Database::defaultCallback, nullptr, &zErrMsg);
     if (rc != SQLITE_OK) {
         sqlite3_free(zErrMsg);
         throw exceptionFailedUpdate();
@@ -520,7 +486,7 @@ void Database::initializeClassValues() {
     //get master domain asset
     sqlite3_stmt* stmt3;
     const char* sqlInt12 = "SELECT assetId,active FROM domainsMasters";
-    rc = sqlite3_prepare_v2(_db, sqlInt12, -1, &stmt3, NULL);
+    rc = sqlite3_prepare_v2(_db, sqlInt12, -1, &stmt3, nullptr);
     if (rc != SQLITE_OK) throw exceptionCreatingStatement();
     string last;
     while (executeSqliteStepWithRetry(stmt3) == SQLITE_ROW) {
@@ -531,7 +497,7 @@ void Database::initializeClassValues() {
         } else {
             _masterDomainAssetId.push_back(assetId);
         }
-    };
+    }
     _masterDomainAssetId.push_back(last);
     sqlite3_finalize(stmt3);
 }
@@ -563,7 +529,7 @@ Database::Database(const string& newFileName) {
 
     //open database
     int rc;
-    rc = sqlite3_open_v2(newFileName.c_str(), &_db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX, NULL);
+    rc = sqlite3_open_v2(newFileName.c_str(), &_db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX, nullptr);
     if (rc) throw exceptionFailedToOpen();
 
     //create needed tables
@@ -573,7 +539,7 @@ Database::Database(const string& newFileName) {
         //get database version number
         sqlite3_stmt* stmt;
         const char* sql = "SELECT `value` FROM `flags` WHERE `key`=\"dbVersion\";";
-        rc = sqlite3_prepare_v2(_db, sql, -1, &stmt, NULL);
+        rc = sqlite3_prepare_v2(_db, sql, -1, &stmt, nullptr);
         if (rc != SQLITE_OK) throw exceptionCreatingStatement();
         if (executeSqliteStepWithRetry(stmt) != SQLITE_ROW) throw exceptionFailedSelect();
         unsigned int dbVersion = sqlite3_column_int(stmt, 0);
@@ -588,64 +554,6 @@ Database::Database(const string& newFileName) {
 
 Database::~Database() {
     sqlite3_close_v2(_db);
-    sqlite3_finalize(_stmtCheckFlag);
-    sqlite3_finalize(_stmtSetFlag);
-    sqlite3_finalize(_stmtGetBlockHeight);
-    sqlite3_finalize(_stmtInsertBlock);
-    sqlite3_finalize(_stmtGetBlockHash);
-    sqlite3_finalize(_stmtCreateUTXO);
-    sqlite3_finalize(_stmtSpendUTXO);
-    sqlite3_finalize(_stmtIsWatchAddress);
-    sqlite3_finalize(_stmtAddWatchAddress);
-    sqlite3_finalize(_stmtGetSpendingAddress);
-    sqlite3_finalize(_stmtAddExchangeRate);
-    sqlite3_finalize(_stmtAddKYC);
-    sqlite3_finalize(_stmtRevokeKYC);
-    sqlite3_finalize(_stmtPruneUTXOs);
-    sqlite3_finalize(_stmtExchangeRatesAtHeight);
-    sqlite3_finalize(_stmtPruneExchangeRate);
-    sqlite3_finalize(_stmtGetVoteCount);
-    sqlite3_finalize(_stmtPruneVote);
-    sqlite3_finalize(_stmtAddVote);
-    sqlite3_finalize(_stmtGetAssetUTXO);
-    sqlite3_finalize(_stmtGetAssetHolders);
-    sqlite3_finalize(_stmtAddAsset);
-    sqlite3_finalize(_stmtUpdateAsset);
-    sqlite3_finalize(_stmtGetAssetIndex);
-    sqlite3_finalize(_stmtGetAssetIndexOnUTXO);
-    sqlite3_finalize(_stmtGetHeightAssetCreated);
-    sqlite3_finalize(_stmtGetAssetRules);
-    sqlite3_finalize(_stmtGetAsset);
-    sqlite3_finalize(_stmtGetKYC);
-    sqlite3_finalize(_stmtGetValidExchangeRate);
-    sqlite3_finalize(_stmtGetCurrentExchangeRate);
-    sqlite3_finalize(_stmtGetNextIPFSJob);
-    sqlite3_finalize(_stmtSetIPFSPauseSync);
-    sqlite3_finalize(_stmtClearNextIPFSJob_a);
-    sqlite3_finalize(_stmtClearNextIPFSJob_b);
-    sqlite3_finalize(_stmtInsertIPFSJob);
-    sqlite3_finalize(_stmtClearIPFSPause);
-    sqlite3_finalize(_stmtSetIPFSLockSync);
-    sqlite3_finalize(_stmtSetIPFSLockJob);
-    sqlite3_finalize(_stmtSetIPFSPauseJob);
-    sqlite3_finalize(_stmtGetDomainAssetId);
-    sqlite3_finalize(_stmtAddDomain);
-    sqlite3_finalize(_stmtRevokeDomain);
-    sqlite3_finalize(_stmtSetDomainMasterAssetId_a);
-    sqlite3_finalize(_stmtSetDomainMasterAssetId_b);
-    sqlite3_finalize(_stmtGetPermanentPaid);
-    sqlite3_finalize(_stmtRemoveNonReachable);
-    sqlite3_finalize(_stmtInsertPermanent);
-    sqlite3_finalize(_stmtRepinAssets);
-    sqlite3_finalize(_stmtRepinPermanentSpecific);
-    sqlite3_finalize(_stmtAddAssetToPool);
-    sqlite3_finalize(_stmtIsAssetInPool);
-    sqlite3_finalize(_stmtPSPFindBadAsset);
-    sqlite3_finalize(_stmtPSPDeleteBadAsset);
-    sqlite3_finalize(_stmtDeletePermanent);
-    sqlite3_finalize(_stmtIsInPermanent);
-    sqlite3_finalize(_stmtGetTotalAssetCounta);
-    sqlite3_finalize(_stmtGetTotalAssetCountb);
 }
 
 /*
@@ -664,16 +572,16 @@ Database::~Database() {
  * time it takes to make all the transactions
  */
 void Database::startTransaction() {
-    char* zErrMsg = 0;
-    sqlite3_exec(_db, "BEGIN TRANSACTION", NULL, NULL, &zErrMsg);
+    char* zErrMsg = nullptr;
+    sqlite3_exec(_db, "BEGIN TRANSACTION", nullptr, nullptr, &zErrMsg);
 }
 
 /**
  * Finishes the batch transaction
  */
 void Database::endTransaction() {
-    char* zErrMsg = 0;
-    sqlite3_exec(_db, "END TRANSACTION", NULL, NULL, &zErrMsg);
+    char* zErrMsg = nullptr;
+    sqlite3_exec(_db, "END TRANSACTION", nullptr, nullptr, &zErrMsg);
 }
 
 /**
@@ -681,9 +589,9 @@ void Database::endTransaction() {
  * may not all be written to the drive so must recheck at startup
  */
 void Database::disableWriteVerification() {
-    char* zErrMsg = 0;
-    sqlite3_exec(_db, "PRAGMA synchronous = OFF", NULL, NULL, &zErrMsg);
-    sqlite3_exec(_db, "PRAGMA journal_mode = MEMORY", NULL, NULL, &zErrMsg);
+    char* zErrMsg = nullptr;
+    sqlite3_exec(_db, "PRAGMA synchronous = OFF", nullptr, nullptr, &zErrMsg);
+    sqlite3_exec(_db, "PRAGMA journal_mode = MEMORY", nullptr, nullptr, &zErrMsg);
 }
 
 /*
@@ -701,7 +609,7 @@ void Database::disableWriteVerification() {
  *  exceptionFailedReset
  */
 void Database::reset() {
-    char* zErrMsg = 0;
+    char* zErrMsg = nullptr;
     int rc;
 
     const char* sql = "DELETE FROM exchange;"
@@ -720,7 +628,7 @@ void Database::reset() {
                       "DELETE FROM domainsMaster;"
                       "INSERT INTO \"domainsMasters\" VALUES (\"Ua7Bd7UVtrzavSHhpHxHZ2nzS2hGaHXRMT9sqy\",true);";
 
-    rc = sqlite3_exec(_db, sql, Database::defaultCallback, 0, &zErrMsg);
+    rc = sqlite3_exec(_db, sql, Database::defaultCallback, nullptr, &zErrMsg);
 
     if (rc != SQLITE_OK) {
         sqlite3_free(zErrMsg);
@@ -746,33 +654,32 @@ uint64_t Database::addAsset(const DigiAsset& asset) {
     int rc;
     uint64_t assetIndex = 0;
     string assetId = asset.getAssetId();
-    if (asset.isAggregable()) { //hybrid and distinct never update so skip this leg
+    if (asset.isAggregable()) { //hybrid and dispersed never update so skip this leg
 
         //only 1 asset can exist with the same assetId so if not locked check if already exists
         if (!asset.isLocked()) {
 
             //get the assetIndex if the asset already exists
-            sqlite3_reset(_stmtGetAssetIndex);
-            sqlite3_bind_text(_stmtGetAssetIndex, 1, assetId.c_str(), assetId.length(), SQLITE_STATIC);
-            rc = executeSqliteStepWithRetry(_stmtGetAssetIndex);
+            auto getAssetIndex=_stmtGetAssetIndex.lock();
+            getAssetIndex.bindText(1,assetId,SQLITE_STATIC);
+            rc=getAssetIndex.executeStep();
             if (rc == SQLITE_ROW) { //if not found its new so leave assetIndex 0
-                assetIndex = sqlite3_column_int(_stmtGetAssetIndex, 0);
+                assetIndex = getAssetIndex.getColumnInt(0);
             }
         }
 
         //update existing asset
         if (assetIndex != 0) {
-            sqlite3_reset(_stmtUpdateAsset);
-            sqlite3_bind_int(_stmtUpdateAsset, 1, asset.getHeightUpdated());
-            string cid = asset.getCID();
-            sqlite3_bind_text(_stmtUpdateAsset, 2, cid.c_str(), cid.length(), SQLITE_STATIC);
+            auto getUpdateAsset=_stmtUpdateAsset.lock();
+            getUpdateAsset.bindInt(1, asset.getHeightUpdated());
+            getUpdateAsset.bindText(2,asset.getCID(),SQLITE_STATIC);
             vector<uint8_t> serializedRules;
             serialize(serializedRules, asset.getRules());
             Blob rules{serializedRules};
-            sqlite3_bind_blob(_stmtUpdateAsset, 3, rules.data(), rules.length(), SQLITE_STATIC);
-            sqlite3_bind_int64(_stmtUpdateAsset, 4, asset.getExpiry());
-            sqlite3_bind_int64(_stmtUpdateAsset, 5, assetIndex);
-            rc = executeSqliteStepWithRetry(_stmtUpdateAsset);
+            getUpdateAsset.bindBlob(3,rules,SQLITE_STATIC);
+            getUpdateAsset.bindInt64(4, asset.getExpiry());
+            getUpdateAsset.bindInt64(5, assetIndex);
+            rc = getUpdateAsset.executeStep();
             if (rc != SQLITE_DONE) {
                 string tempErrorMessage = sqlite3_errmsg(_db);
                 throw exceptionFailedUpdate();
@@ -782,20 +689,18 @@ uint64_t Database::addAsset(const DigiAsset& asset) {
     }
 
     //insert new asset
-    sqlite3_reset(_stmtAddAsset);
-    sqlite3_bind_text(_stmtAddAsset, 1, assetId.c_str(), assetId.length(), SQLITE_STATIC);
-    string issuingAddress = asset.getIssuer().getAddress();
-    sqlite3_bind_text(_stmtAddAsset, 2, issuingAddress.c_str(), issuingAddress.length(), SQLITE_STATIC);
-    string cid = asset.getCID();
-    sqlite3_bind_text(_stmtAddAsset, 3, cid.c_str(), cid.length(), SQLITE_STATIC);
+    auto addAsset=_stmtAddAsset.lock();
+    addAsset.bindText(1,assetId,SQLITE_STATIC);
+    addAsset.bindText(2,asset.getIssuer().getAddress(),SQLITE_STATIC);
+    addAsset.bindText(3,asset.getCID(),SQLITE_STATIC);
     vector<uint8_t> serializedRules;
     serialize(serializedRules, asset.getRules());
     Blob rules{serializedRules};
-    sqlite3_bind_blob(_stmtAddAsset, 4, rules.data(), rules.length(), SQLITE_STATIC);
-    sqlite3_bind_int(_stmtAddAsset, 5, asset.getHeightCreated());
-    sqlite3_bind_int(_stmtAddAsset, 6, asset.getHeightUpdated()); //will be same as created
-    sqlite3_bind_int64(_stmtAddAsset, 7, asset.getExpiry());
-    rc = executeSqliteStepWithRetry(_stmtAddAsset);
+    addAsset.bindBlob(4, rules, SQLITE_STATIC);
+    addAsset.bindInt(5, asset.getHeightCreated());
+    addAsset.bindInt(6, asset.getHeightUpdated()); //will be same as created
+    addAsset.bindInt64(7, asset.getExpiry());
+    rc = addAsset.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedInsert();
@@ -809,16 +714,13 @@ uint64_t Database::addAsset(const DigiAsset& asset) {
  * @param assetId
  * @return
  */
-DigiAssetRules Database::getRules(const string& assetId) const {
-    int rc;
-    sqlite3_reset(_stmtGetAssetRules);
-    sqlite3_bind_text(_stmtGetAssetRules, 1, assetId.c_str(), assetId.length(), SQLITE_STATIC);
-    rc = executeSqliteStepWithRetry(_stmtGetAssetRules);
-    if (rc != SQLITE_ROW) return DigiAssetRules();
+DigiAssetRules Database::getRules(const string& assetId) {
+    auto getAssetRules=_stmtGetAssetRules.lock();
+    getAssetRules.bindText(1, assetId, SQLITE_STATIC);
+    int rc = getAssetRules.executeStep();
+    if (rc != SQLITE_ROW) return {};
 
-    vector<uint8_t> serializedRules = Blob(sqlite3_column_blob(_stmtGetAssetRules, 0),
-                                           sqlite3_column_bytes(_stmtGetAssetRules, 0))
-                                              .vector();
+    vector<uint8_t> serializedRules = getAssetRules.getColumnBlob(0).vector();
     DigiAssetRules rules;
     size_t i = 0;
     deserialize(serializedRules, i, rules);
@@ -831,13 +733,12 @@ DigiAssetRules Database::getRules(const string& assetId) const {
  */
 unsigned int
 Database::getAssetHeightCreated(const string& assetId, unsigned int backupHeight, uint64_t& assetIndex) {
-    int rc;
-    sqlite3_reset(_stmtGetHeightAssetCreated);
-    sqlite3_bind_text(_stmtGetHeightAssetCreated, 1, assetId.c_str(), assetId.length(), SQLITE_STATIC);
-    rc = executeSqliteStepWithRetry(_stmtGetHeightAssetCreated);
+    auto getHeightAssetCreated=_stmtGetHeightAssetCreated.lock();
+    getHeightAssetCreated.bindText(1, assetId, SQLITE_STATIC);
+    int rc = getHeightAssetCreated.executeStep();
     if (rc == SQLITE_ROW) { //if not found its new so leave assetIndex 0
-        assetIndex = sqlite3_column_int(_stmtGetHeightAssetCreated, 0);
-        return sqlite3_column_int(_stmtGetHeightAssetCreated, 1);
+        assetIndex = getHeightAssetCreated.getColumnInt(0);
+        return getHeightAssetCreated.getColumnInt(1);
     }
     return backupHeight;
 }
@@ -848,24 +749,21 @@ Database::getAssetHeightCreated(const string& assetId, unsigned int backupHeight
  * @param amount - optional number of assets to include in object
  * @return
  */
-DigiAsset Database::getAsset(uint64_t assetIndex, uint64_t amount) const {
+DigiAsset Database::getAsset(uint64_t assetIndex, uint64_t amount) {
     //get data in assets table
-    int rc;
-    sqlite3_reset(_stmtGetAsset);
-    sqlite3_bind_int64(_stmtGetAsset, 1, assetIndex);
-    rc = executeSqliteStepWithRetry(_stmtGetAsset);
+    auto getAsset=_stmtGetAsset.lock();
+    getAsset.bindInt64(1, assetIndex);
+    int rc = getAsset.executeStep();
     if (rc != SQLITE_ROW) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedSelect();
     }
-    string assetId = reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetAsset, 0));
-    string cid = reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetAsset, 1));
-    string issuerAddress = reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetAsset, 2));
-    vector<uint8_t> serializedRules = Blob(sqlite3_column_blob(_stmtGetAsset, 3),
-                                           sqlite3_column_bytes(_stmtGetAsset, 3))
-                                              .vector();
-    unsigned int heightCreated = sqlite3_column_int(_stmtGetAsset, 4);
-    unsigned int heightUpdated = sqlite3_column_int(_stmtGetAsset, 5);
+    string assetId = getAsset.getColumnText(0);
+    string cid = getAsset.getColumnText(1);
+    string issuerAddress = getAsset.getColumnText(2);
+    vector<uint8_t> serializedRules = getAsset.getColumnBlob(3).vector();
+    unsigned int heightCreated = getAsset.getColumnInt(4);
+    unsigned int heightUpdated = getAsset.getColumnInt(5);
 
     //lookup kyc and rules
     KYC issuer = getAddressKYC(issuerAddress);
@@ -877,29 +775,35 @@ DigiAsset Database::getAsset(uint64_t assetIndex, uint64_t amount) const {
     return {assetIndex, assetId, cid, issuer, rules, heightCreated, heightUpdated, amount};
 }
 
-uint64_t Database::getAssetIndex(const string& assetId, const string& txid, unsigned int vout) const {
+uint64_t Database::getAssetIndex(const string& assetId, const string& txid, unsigned int vout) {
     //see if the asset exists and if only 1 index
-    sqlite3_reset(_stmtGetAssetIndex);
-    sqlite3_bind_text(_stmtGetAssetIndex, 1, assetId.c_str(), assetId.length(), SQLITE_STATIC);
-    int rc = executeSqliteStepWithRetry(_stmtGetAssetIndex);
-    if (rc != SQLITE_ROW) {
-        throw out_of_range("assetIndex does not exist");
-    }
-    uint64_t assetIndex = sqlite3_column_int(_stmtGetAssetIndex, 0);
+    uint64_t assetIndex;
+    { //shorten life of database lock
+        auto getAssetIndex = _stmtGetAssetIndex.lock();
+        getAssetIndex.bindText(1, assetId, SQLITE_STATIC);
+        int rc = getAssetIndex.executeStep();
+        if (rc != SQLITE_ROW) {
+            throw out_of_range("assetIndex does not exist");
+        }
+        assetIndex = getAssetIndex.getColumnInt(0);
 
-    //check if more than 1
-    rc = executeSqliteStepWithRetry(_stmtGetAssetIndex);
-    if (rc != SQLITE_ROW) return assetIndex; //there was only 1
+
+        //check if more than 1
+        rc = getAssetIndex.executeStep();
+        if (rc != SQLITE_ROW) return assetIndex; //there was only 1
+    }
 
     //more than 1 so see if the txid and vout provided match a utxo
     if (txid.empty()) throw out_of_range("specific utxo needed");
     vector<uint64_t> assetIndexPossibilities;
-    sqlite3_reset(_stmtGetAssetIndexOnUTXO);
-    sqlite3_bind_text(_stmtGetAssetIndexOnUTXO, 1, assetId.c_str(), assetId.length(), SQLITE_STATIC);
-    sqlite3_bind_text(_stmtGetAssetIndexOnUTXO, 2, txid.c_str(), txid.length(), SQLITE_STATIC);
-    sqlite3_bind_int(_stmtGetAssetIndexOnUTXO, 3, vout);
-    while (executeSqliteStepWithRetry(_stmtGetAssetIndexOnUTXO) == SQLITE_ROW) {
-        assetIndexPossibilities.push_back(sqlite3_column_int(_stmtGetAssetIndexOnUTXO, 0));
+    { //shorten life of database lock
+        auto getAssetIndexOnUTXO = _stmtGetAssetIndexOnUTXO.lock();
+        Blob txidBlob(txid);
+        getAssetIndexOnUTXO.bindBlob(1, txidBlob, SQLITE_STATIC);
+        getAssetIndexOnUTXO.bindInt(2, vout);
+        while (getAssetIndexOnUTXO.executeStep() == SQLITE_ROW) {
+            assetIndexPossibilities.push_back(getAssetIndexOnUTXO.getColumnInt(0));
+        }
     }
 
     //filter possibilities for those that are the same assetId
@@ -910,16 +814,16 @@ uint64_t Database::getAssetIndex(const string& assetId, const string& txid, unsi
     throw out_of_range("assetId not found in utxo");
 }
 
-vector<uint64_t> Database::getAssetIndexs(const std::string& assetId) const {
+vector<uint64_t> Database::getAssetIndexes(const std::string& assetId) {
     vector<uint64_t> assetIndexes;
 
     // Reset the prepared statement to its initial state and bind the assetId parameter
-    sqlite3_reset(_stmtGetAssetIndex);
-    sqlite3_bind_text(_stmtGetAssetIndex, 1, assetId.c_str(), -1, SQLITE_STATIC);
+    auto getAssetIndex=_stmtGetAssetIndex.lock();
+    getAssetIndex.bindText(1, assetId, SQLITE_STATIC);
 
     // Execute the query and collect all matching asset indexes
-    while (executeSqliteStepWithRetry(_stmtGetAssetIndex) == SQLITE_ROW) {
-        uint64_t assetIndex = sqlite3_column_int64(_stmtGetAssetIndex, 0);
+    while (getAssetIndex.executeStep() == SQLITE_ROW) {
+        uint64_t assetIndex = getAssetIndex.getColumnInt64(0);
         assetIndexes.push_back(assetIndex);
     }
 
@@ -947,17 +851,16 @@ int Database::getFlagInt(const string& flag) {
     }
 
     //get from database
-    int rc;
-    sqlite3_reset(_stmtCheckFlag);
-    sqlite3_bind_text(_stmtCheckFlag, 1, flag.c_str(), flag.length(), SQLITE_STATIC);
-    rc = executeSqliteStepWithRetry(_stmtCheckFlag);
+    auto checkFlag=_stmtCheckFlag.lock();
+    checkFlag.bindText(1, flag, SQLITE_STATIC);
+    int rc = checkFlag.executeStep();
     if (rc != SQLITE_ROW) { //there should always be one
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedSelect(); //failed to check database
     }
 
     //store in ram and return
-    _flagState[flag] = sqlite3_column_int(_stmtCheckFlag, 0);
+    _flagState[flag] = checkFlag.getColumnInt(0);
     return _flagState[flag];
 }
 
@@ -1002,11 +905,10 @@ void Database::setFlagInt(const std::string& flag, int state) {
     if (getFlagInt(flag) == state) return; //no need to do anything
 
     //store in database
-    int rc;
-    sqlite3_reset(_stmtSetFlag);
-    sqlite3_bind_int(_stmtSetFlag, 1, state);
-    sqlite3_bind_text(_stmtSetFlag, 2, flag.c_str(), flag.length(), nullptr);
-    rc = executeSqliteStepWithRetry(_stmtSetFlag);
+    auto setFlag=_stmtSetFlag.lock();
+    setFlag.bindInt(1, state);
+    setFlag.bindText(2, flag, SQLITE_STATIC);
+    int rc = setFlag.executeStep();
     if (rc != SQLITE_DONE) { //there should always be one
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedUpdate(); //failed to check database
@@ -1065,16 +967,14 @@ void Database::setBeenPrunedNonAssetUTXOHistory(bool state) {
  * @param hash
  */
 void Database::insertBlock(uint height, const std::string& hash, unsigned int time, unsigned char algo, double difficulty) {
-    int rc;
-    sqlite3_reset(_stmtInsertBlock);
-    sqlite3_bind_int(_stmtInsertBlock, 1, height);
+    auto insertBlock=_stmtInsertBlock.lock();
+    insertBlock.bindInt(1, height);
     Blob hashBlob = Blob(hash);
-    sqlite3_bind_blob(_stmtInsertBlock, 2, hashBlob.data(), SHA256_LENGTH,
-                      SQLITE_STATIC); //could use hashBlob.length() but always SHA256_LENGTH
-    sqlite3_bind_int(_stmtInsertBlock, 3, time);
-    sqlite3_bind_int(_stmtInsertBlock, 4, algo);
-    sqlite3_bind_double(_stmtInsertBlock, 5, difficulty);
-    rc = executeSqliteStepWithRetry(_stmtInsertBlock);
+    insertBlock.bindBlob(2, hashBlob, SQLITE_STATIC);
+    insertBlock.bindInt(3, time);
+    insertBlock.bindInt(4, algo);
+    insertBlock.bindDouble(5, difficulty);
+    int rc = insertBlock.executeStep();
     if (rc != SQLITE_DONE) { //there should always be one
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedInsert(); //failed to check database
@@ -1088,16 +988,14 @@ void Database::insertBlock(uint height, const std::string& hash, unsigned int ti
  * @param height
  * @param hash
  */
-std::string Database::getBlockHash(uint height) const {
-    int rc;
-    sqlite3_reset(_stmtGetBlockHash);
-    sqlite3_bind_int(_stmtGetBlockHash, 1, height);
-    rc = executeSqliteStepWithRetry(_stmtGetBlockHash);
+std::string Database::getBlockHash(uint height) {
+    auto getBlockHash=_stmtGetBlockHash.lock();
+    getBlockHash.bindInt(1, height);
+    int rc = getBlockHash.executeStep();
     if (rc != SQLITE_ROW) {
         throw exceptionDataPruned();
     }
-    Blob hash = Blob(sqlite3_column_blob(_stmtGetBlockHash, 0),
-                     SHA256_LENGTH); // could have used sqlite3_column_bytes(_stmtGetBlockHash,0);  but always 8
+    Blob hash = getBlockHash.getColumnBlob(0);
     return hash.toHex();
 }
 
@@ -1106,14 +1004,13 @@ std::string Database::getBlockHash(uint height) const {
  * Possible Errors:
  *  exceptionFailedSelect
  */
-uint Database::getBlockHeight() const {
-    int rc;
-    sqlite3_reset(_stmtGetBlockHeight);
-    rc = executeSqliteStepWithRetry(_stmtGetBlockHeight);
+uint Database::getBlockHeight() {
+    auto getBlockHeight=_stmtGetBlockHeight.lock();
+    int rc = getBlockHeight.executeStep();
     if (rc != SQLITE_ROW) { //there should always be one
         throw exceptionFailedSelect();
     }
-    return sqlite3_column_int(_stmtGetBlockHeight, 0);
+    return getBlockHeight.getColumnInt(0);
 }
 
 /**
@@ -1124,7 +1021,7 @@ uint Database::getBlockHeight() const {
  */
 void Database::clearBlocksAboveHeight(uint height) {
     int rc;
-    char* zErrMsg = 0;
+    char* zErrMsg = nullptr;
     string lineEnd = to_string(height) + ";";
     const string sql = "DELETE FROM assets WHERE heightCreated>=" + lineEnd +
                        "DELETE FROM exchange WHERE height>=" + lineEnd +
@@ -1135,7 +1032,7 @@ void Database::clearBlocksAboveHeight(uint height) {
                        "DELETE FROM votes WHERE height>=" + lineEnd +
                        "DELETE FROM blocks WHERE height>" + lineEnd;
 
-    rc = sqlite3_exec(_db, sql.c_str(), Database::defaultCallback, 0, &zErrMsg);
+    rc = sqlite3_exec(_db, sql.c_str(), Database::defaultCallback, nullptr, &zErrMsg);
     if (rc != SQLITE_OK) {
         sqlite3_free(zErrMsg);
         throw exceptionFailedDelete();
@@ -1156,10 +1053,11 @@ void Database::clearBlocksAboveHeight(uint height) {
 
 /**
  * Creates a utxo entry in the database
+ * @param issuance- 0 nothing, 1 asset, 2 block
  * Possible Errors:
  *  exceptionFailedInsert
  */
-void Database::createUTXO(const AssetUTXO& value, unsigned int heightCreated) {
+void Database::createUTXO(const AssetUTXO& value, unsigned int heightCreated, bool assetIssuance) {
     if (value.address.empty()) return; //op return don't store
     if (value.assets.empty() && getBeenPrunedNonAssetUTXOHistory()) {
         //_recentNonAssetUTXO.add(value.txid, value.vout); //keep temp cache that this is non asset utxo
@@ -1168,17 +1066,17 @@ void Database::createUTXO(const AssetUTXO& value, unsigned int heightCreated) {
     int rc;
 
     //add the main utxo
-    sqlite3_reset(_stmtCreateUTXO);
-    string address = value.address;
-    sqlite3_bind_text(_stmtCreateUTXO, 1, address.c_str(), address.length(), nullptr);
+    auto createUTXO=_stmtCreateUTXO.lock();
+    createUTXO.bindText(1, value.address, SQLITE_STATIC);
     Blob blobTXID = Blob(value.txid);
-    sqlite3_bind_blob(_stmtCreateUTXO, 2, blobTXID.data(), SHA256_LENGTH, SQLITE_STATIC);
-    sqlite3_bind_int(_stmtCreateUTXO, 3, value.vout);
-    sqlite3_bind_null(_stmtCreateUTXO, 4);
-    sqlite3_bind_int(_stmtCreateUTXO, 5, 1);
-    sqlite3_bind_int64(_stmtCreateUTXO, 6, value.digibyte);
-    sqlite3_bind_int(_stmtCreateUTXO, 7, heightCreated);
-    rc = executeSqliteStepWithRetry(_stmtCreateUTXO);
+    createUTXO.bindBlob(2, blobTXID, SQLITE_STATIC);
+    createUTXO.bindInt(3, value.vout);
+    createUTXO.bindNull(4);
+    createUTXO.bindInt(5, 1);
+    createUTXO.bindInt64(6, value.digibyte);
+    createUTXO.bindInt(7, heightCreated);
+    createUTXO.bindInt(8, 0);
+    rc = createUTXO.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedInsert();
@@ -1186,19 +1084,19 @@ void Database::createUTXO(const AssetUTXO& value, unsigned int heightCreated) {
 
     //add any assets
     for (size_t aout = 0; aout < value.assets.size(); aout++) {
-        sqlite3_reset(_stmtCreateUTXO);
-        string address = value.address;
-        sqlite3_bind_text(_stmtCreateUTXO, 1, address.c_str(), address.length(), nullptr);
-        Blob blobTXID = Blob(value.txid);
-        sqlite3_bind_blob(_stmtCreateUTXO, 2, blobTXID.data(), SHA256_LENGTH, SQLITE_STATIC);
-        sqlite3_bind_int(_stmtCreateUTXO, 3, value.vout);
-        sqlite3_bind_int(_stmtCreateUTXO, 4, aout);
-        sqlite3_bind_int64(_stmtCreateUTXO, 5, value.assets[aout].getAssetIndex());
-        sqlite3_bind_int64(_stmtCreateUTXO, 6, value.assets[aout].getCount());
-        sqlite3_bind_int(_stmtCreateUTXO, 7, heightCreated);
-        rc = executeSqliteStepWithRetry(_stmtCreateUTXO);
+        createUTXO.reset();
+        createUTXO.bindText(1, value.address, SQLITE_STATIC);
+        blobTXID = Blob(value.txid);
+        createUTXO.bindBlob(2, blobTXID);
+        createUTXO.bindInt(3, value.vout);
+        createUTXO.bindInt(4,aout);
+        createUTXO.bindInt64(5, value.assets[aout].getAssetIndex());
+        createUTXO.bindInt64(6, value.assets[aout].getCount());
+        createUTXO.bindInt(7, heightCreated);
+        createUTXO.bindInt(8, assetIssuance);
+        rc = createUTXO.executeStep();
         if (rc != SQLITE_DONE) {
-            string errorMessage = sqlite3_errmsg(_db);
+            string tempErrorMessage = sqlite3_errmsg(_db);
             throw exceptionFailedInsert();
         }
     }
@@ -1209,14 +1107,15 @@ void Database::createUTXO(const AssetUTXO& value, unsigned int heightCreated) {
  * Possible Errors:
  *  exceptionFailedUpdate
  */
-void Database::spendUTXO(const std::string& txid, unsigned int vout, unsigned int heightSpent) {
-    int rc;
-    sqlite3_reset(_stmtSpendUTXO);
+void Database::spendUTXO(const std::string& txid, unsigned int vout, unsigned int heightSpent, const string& spentTXID) {
+    auto spendUTXO=_stmtSpendUTXO.lock();
     Blob blobTXID = Blob(txid);
-    sqlite3_bind_int(_stmtSpendUTXO, 1, heightSpent);
-    sqlite3_bind_blob(_stmtSpendUTXO, 2, blobTXID.data(), SHA256_LENGTH, SQLITE_STATIC);
-    sqlite3_bind_int(_stmtSpendUTXO, 3, vout);
-    rc = executeSqliteStepWithRetry(_stmtSpendUTXO);
+    Blob blobSpendingTXID = Blob(spentTXID);
+    spendUTXO.bindInt(1, heightSpent);
+    spendUTXO.bindBlob(2, blobSpendingTXID, SQLITE_STATIC);
+    spendUTXO.bindBlob(3, blobTXID, SQLITE_STATIC);
+    spendUTXO.bindInt(4, vout);
+    int rc = spendUTXO.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedUpdate();
@@ -1224,12 +1123,11 @@ void Database::spendUTXO(const std::string& txid, unsigned int vout, unsigned in
 }
 
 std::string Database::getSendingAddress(const string& txid, unsigned int vout) {
-    int rc;
-    sqlite3_reset(_stmtGetSpendingAddress);
+    auto getSpendingAddress=_stmtGetSpendingAddress.lock();
     Blob blobTXID = Blob(txid);
-    sqlite3_bind_blob(_stmtGetSpendingAddress, 1, blobTXID.data(), SHA256_LENGTH, SQLITE_STATIC);
-    sqlite3_bind_int(_stmtGetSpendingAddress, 2, vout);
-    rc = executeSqliteStepWithRetry(_stmtGetSpendingAddress);
+    getSpendingAddress.bindBlob(1, blobTXID, SQLITE_STATIC);
+    getSpendingAddress.bindInt(2, vout);
+    int rc = getSpendingAddress.executeStep();
     if (rc != SQLITE_ROW) {
         //try checking wallet
         AppMain* main = AppMain::GetInstance();
@@ -1243,7 +1141,7 @@ std::string Database::getSendingAddress(const string& txid, unsigned int vout) {
         //could not be found
         throw exceptionFailedSelect();
     }
-    return reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetSpendingAddress, 0));
+    return getSpendingAddress.getColumnText(0);
 }
 
 /**
@@ -1252,22 +1150,25 @@ std::string Database::getSendingAddress(const string& txid, unsigned int vout) {
  */
 void Database::pruneUTXO(unsigned int height) {
     //prune UTXOs
-    int rc;
-    sqlite3_reset(_stmtPruneUTXOs);
-    sqlite3_bind_int(_stmtPruneUTXOs, 1, height);
-    rc = executeSqliteStepWithRetry(_stmtPruneUTXOs);
-    if (rc != SQLITE_DONE) {
-        string tempErrorMessage = sqlite3_errmsg(_db);
-        throw exceptionFailedDelete();
+    {
+        auto pruneUTXOs=_stmtPruneUTXOs.lock();
+        pruneUTXOs.bindInt(1, height);
+        int rc = pruneUTXOs.executeStep();
+        if (rc != SQLITE_DONE) {
+            string tempErrorMessage = sqlite3_errmsg(_db);
+            throw exceptionFailedDelete();
+        }
     }
 
     //mark blocks that can't be rolled back anymore
-    sqlite3_reset(_stmtRemoveNonReachable);
-    sqlite3_bind_int(_stmtRemoveNonReachable, 1, height);
-    rc = executeSqliteStepWithRetry(_stmtRemoveNonReachable);
-    if (rc != SQLITE_DONE) {
-        string tempErrorMessage = sqlite3_errmsg(_db);
-        throw exceptionFailedUpdate();
+    {
+        auto removeNonReachable=_stmtRemoveNonReachable.lock();
+        removeNonReachable.bindInt(1, height);
+        int rc = removeNonReachable.executeStep();
+        if (rc != SQLITE_DONE) {
+            string tempErrorMessage = sqlite3_errmsg(_db);
+            throw exceptionFailedUpdate();
+        }
     }
 
     //set was pruned flag
@@ -1284,26 +1185,28 @@ void Database::pruneUTXO(unsigned int height) {
  */
 AssetUTXO Database::getAssetUTXO(const string& txid, unsigned int vout) {
     //try to get data from database
-    sqlite3_reset(_stmtGetAssetUTXO);
-    Blob blobTXID = Blob(txid);
-    sqlite3_bind_blob(_stmtGetAssetUTXO, 1, blobTXID.data(), SHA256_LENGTH, SQLITE_STATIC);
-    sqlite3_bind_int(_stmtGetAssetUTXO, 2, vout);
     AssetUTXO result;
-    result.txid = txid;
-    result.vout = vout;
-    bool exists = false;
-    while (executeSqliteStepWithRetry(_stmtGetAssetUTXO) == SQLITE_ROW) {
-        exists = true;
-        unsigned int assetIndex = sqlite3_column_int(_stmtGetAssetUTXO, 2);
-        uint64_t amount = sqlite3_column_int64(_stmtGetAssetUTXO, 3);
-        if (assetIndex == 1) {
-            result.address = reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetAssetUTXO, 0));
-            result.digibyte = amount;
-        } else {
-            result.assets.emplace_back(getAsset(assetIndex, amount));
+    {
+        auto getAssetUTXO=_stmtGetAssetUTXO.lock();
+        Blob blobTXID = Blob(txid);
+        getAssetUTXO.bindBlob(1, blobTXID, SQLITE_STATIC);
+        getAssetUTXO.bindInt(2, vout);
+        result.txid = txid;
+        result.vout = vout;
+        bool exists = false;
+        while (getAssetUTXO.executeStep() == SQLITE_ROW) {
+            exists = true;
+            unsigned int assetIndex = getAssetUTXO.getColumnInt(2);
+            uint64_t amount = getAssetUTXO.getColumnInt64(3);
+            if (assetIndex == 1) {
+                result.address = getAssetUTXO.getColumnText(0);
+                result.digibyte = amount;
+            } else {
+                result.assets.emplace_back(getAsset(assetIndex, amount));
+            }
         }
+        if (exists) return result;
     }
-    if (exists) return result;
 
     //check if we can/should get from the wallet
     AppMain* main = AppMain::GetInstance();
@@ -1319,14 +1222,111 @@ AssetUTXO Database::getAssetUTXO(const string& txid, unsigned int vout) {
     return result;
 }
 
+/**
+ * Returns a list of UTXOs for a specific address.
+ * Warning will not return all utxos if not storing non asset utxos and the address is not part of wallet
+ * @param address
+ * @return
+ */
+std::vector<AssetUTXO> Database::getAddressUTXOs(const string& address) {
+    vector<AssetUTXO> results;
+    AssetUTXO entry;
+    entry.address=address;
 
-std::vector<AssetHolder> Database::getAssetHolders(uint64_t assetIndex) const {
-    sqlite3_reset(_stmtGetAssetHolders);
-    sqlite3_bind_int64(_stmtGetAssetHolders, 1, assetIndex);
+    //get all utxos that include DigiAssets
+    Blob lastTxid{"00"};
+    {
+        auto getValidUTXO = _stmtGetValidUTXO.lock();
+        getValidUTXO.bindText(1, address, SQLITE_STATIC);
+        int lastVout=-1;
+        while (getValidUTXO.executeStep() == SQLITE_ROW) {
+            //get next row value
+            Blob txid = getValidUTXO.getColumnBlob(0);
+            int vout = getValidUTXO.getColumnInt(1);
+            unsigned int aout = getValidUTXO.getColumnInt(2);
+            unsigned int assetIndex = getValidUTXO.getColumnInt(3);
+            uint64_t amount = getValidUTXO.getColumnInt64(4);
+
+            //check if new utxo
+            if ((lastTxid != txid) || (lastVout != vout)) {
+                //save last utxo to the results
+                if (lastTxid.length() != 1) {
+                    results.emplace_back(entry);
+                }
+
+                //reset entry to new utxo values
+                lastVout=vout;
+                entry.txid = txid.toHex();
+                entry.vout = vout;
+                entry.address = address;
+                entry.digibyte = 0;
+                entry.assets = {};
+            }
+
+            //add current row data
+            if (assetIndex == 1) {
+                //set the DGB
+                entry.digibyte = amount;
+            } else {
+                //sql statement will always return in order
+                entry.assets.push_back(getAsset(assetIndex, amount));
+            }
+        }
+    }
+
+    //save last entry
+    if (lastTxid.length()!=1) {
+        results.emplace_back(entry);
+    }
+
+    //check if there are any non asset utxo missing from the database
+    if (getBeenPrunedNonAssetUTXOHistory()) {
+        //see if we can get the rest of the data from the wallet
+        DigiByteCore* dgb=AppMain::GetInstance()->getDigiByteCore();
+        vector<unspenttxout_t> walletUtxoData;
+        try {
+            walletUtxoData=dgb->listUnspent(1,99999999,{address});
+        } catch (...) {
+            //ignore errors
+        }
+        for (const auto& walletUtxo : walletUtxoData) {
+            //search to see if already in results
+            bool isDuplicate = false;
+            for (const auto& resultUtxo : results) {
+                if (resultUtxo.txid == walletUtxo.txid && resultUtxo.vout == walletUtxo.n) {
+                    isDuplicate = true;
+                    break;
+                }
+            }
+
+            //if not in results add to results
+            if (!isDuplicate) {
+                AssetUTXO newUtxo;
+                newUtxo.txid = walletUtxo.txid;
+                newUtxo.vout = walletUtxo.n;
+                newUtxo.address = walletUtxo.address;
+                newUtxo.digibyte = static_cast<uint64_t>(walletUtxo.amount * 100000000); // Assuming amount needs to be in satoshis
+                newUtxo.assets = {}; // No assets for non-asset UTXOs
+                results.emplace_back(newUtxo);
+            }
+        }
+    }
+
+    return results;
+}
+
+/**
+ * Returns a list of asset holders for a specific assetIndex
+ * @param assetIndex
+ * @return
+ */
+std::vector<AssetHolder> Database::getAssetHolders(uint64_t assetIndex) {
+    auto getAssetHolders=_stmtGetAssetHolders.lock();
+    getAssetHolders.bindInt64(1, assetIndex);
     vector<AssetHolder> result;
-    while (executeSqliteStepWithRetry(_stmtGetAssetHolders) == SQLITE_ROW) {
-        string address = reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetAssetHolders, 0));
-        uint64_t count = sqlite3_column_int64(_stmtGetAssetHolders, 1);
+    while (getAssetHolders.executeStep() == SQLITE_ROW) {
+        string address = getAssetHolders.getColumnText(0);
+        uint64_t count = getAssetHolders.getColumnInt64(1);
         result.emplace_back(AssetHolder{
                 .address = address,
                 .count = count});
@@ -1340,11 +1340,11 @@ std::vector<AssetHolder> Database::getAssetHolders(uint64_t assetIndex) const {
  * @param assetIndex
  * @return
  */
-uint64_t Database::getTotalAssetCount(uint64_t assetIndex) const {
-    sqlite3_reset(_stmtGetTotalAssetCounta);
-    sqlite3_bind_int64(_stmtGetTotalAssetCounta, 1, assetIndex);
-    if (executeSqliteStepWithRetry(_stmtGetTotalAssetCounta) != SQLITE_ROW) throw exceptionFailedSelect();
-    return sqlite3_column_int64(_stmtGetTotalAssetCounta, 0);
+uint64_t Database::getTotalAssetCount(uint64_t assetIndex) {
+    auto getTotalAssetCounta=_stmtGetTotalAssetCounta.lock();
+    getTotalAssetCounta.bindInt64(1, assetIndex);
+    if (getTotalAssetCounta.executeStep() != SQLITE_ROW) throw exceptionFailedSelect();
+    return getTotalAssetCounta.getColumnInt64(0);
 }
 
 /**
@@ -1353,11 +1353,113 @@ uint64_t Database::getTotalAssetCount(uint64_t assetIndex) const {
  * @param assetIndex
  * @return
  */
-uint64_t Database::getTotalAssetCount(const string& assetId) const {
-    sqlite3_reset(_stmtGetTotalAssetCountb);
-    sqlite3_bind_text(_stmtGetTotalAssetCountb, 1, assetId.c_str(), assetId.length(), nullptr);
-    if (executeSqliteStepWithRetry(_stmtGetTotalAssetCountb) != SQLITE_ROW) throw exceptionFailedSelect();
-    return sqlite3_column_int64(_stmtGetTotalAssetCountb, 0);
+uint64_t Database::getTotalAssetCount(const string& assetId) {
+    auto getTotalAssetCountb=_stmtGetTotalAssetCountb.lock();
+    getTotalAssetCountb.bindText(1, assetId, SQLITE_STATIC);
+    if (getTotalAssetCountb.executeStep() != SQLITE_ROW) throw exceptionFailedSelect();
+    return getTotalAssetCountb.getColumnInt64(0);
+}
+
+/**
+ * Returns the original number assets that exist of this specific type.
+ * The difference between this and the other getOriginalAssetCount function is that if the asset has sub types this will only give total of the sub type provided
+ * @param assetIndex
+ * @return
+ */
+uint64_t Database::getOriginalAssetCount(uint64_t assetIndex) {
+    if (getBeenPrunedUTXOHistory()>-1) throw exceptionDataPruned();
+    auto getOriginalAssetCounta=_stmtGetOriginalAssetCounta.lock();
+    getOriginalAssetCounta.bindInt64(1, assetIndex);
+    if (getOriginalAssetCounta.executeStep() != SQLITE_ROW) throw exceptionFailedSelect();
+    return getOriginalAssetCounta.getColumnInt64(0);
+}
+
+/**
+ * Returns the original number assets that exist of this specific type.
+ * The difference between this and the other getOriginalAssetCount function is this if the asset has sub types this will provide the total of all sub types
+ * @param assetIndex
+ * @return
+ */
+uint64_t Database::getOriginalAssetCount(const string& assetId) {
+    if (getBeenPrunedUTXOHistory()>-1) throw exceptionDataPruned();
+    auto getOriginalAssetCountb=_stmtGetOriginalAssetCountb.lock();
+    getOriginalAssetCountb.bindText(1, assetId, SQLITE_STATIC);
+    if (getOriginalAssetCountb.executeStep() != SQLITE_ROW) throw exceptionFailedSelect();
+    return getOriginalAssetCountb.getColumnInt64(0);
+}
+
+/**
+ * Returns a list of TXIDs that involve this asset in order they happened
+ * The difference between this and the other getAssetTxHistory function is that if the asset has sub types this will only give history for the sub type provide
+ * @param assetIndex
+ * @return
+ */
+std::vector<std::string> Database::getAssetTxHistory(uint64_t assetIndex) {
+    if (getBeenPrunedUTXOHistory()>-1) throw exceptionDataPruned();
+    vector<string> results;
+    auto getAssetTxHistorya=_stmtGetAssetTxHistorya.lock();
+    getAssetTxHistorya.bindInt64(1, assetIndex);
+    getAssetTxHistorya.bindInt64(2, assetIndex);
+    getAssetTxHistorya.bindInt64(3, assetIndex);
+    while (getAssetTxHistorya.executeStep() == SQLITE_ROW) {
+        Blob txid=getAssetTxHistorya.getColumnBlob(0);
+        results.push_back(txid.toHex());
+    }
+    return results;
+}
+
+/**
+ * Returns a list of TXIDs that involve this asset in order they happened
+ * The difference between this and the other getAssetTxHistory function is this if the asset has sub types this will provide the history of all sub types
+ * @param assetIndex
+ * @return
+ */
+std::vector<std::string> Database::getAssetTxHistory(const string& assetId) {
+    if (getBeenPrunedUTXOHistory()>-1) throw exceptionDataPruned();
+    vector<string> results;
+    auto getAssetTxHistoryb=_stmtGetAssetTxHistoryb.lock();
+    getAssetTxHistoryb.bindText(1, assetId, SQLITE_STATIC);
+    getAssetTxHistoryb.bindText(2, assetId, SQLITE_STATIC);
+    getAssetTxHistoryb.bindText(3, assetId, SQLITE_STATIC);
+    while (getAssetTxHistoryb.executeStep() == SQLITE_ROW) {
+        Blob txid=getAssetTxHistoryb.getColumnBlob(0);
+        results.push_back(txid.toHex());
+    }
+    return results;
+}
+
+/**
+ * Returns list of TXIDs that involve an address
+ * @param address
+ * @return
+ */
+std::vector<std::string> Database::getAddressTxList(const string& address) {
+    if (getBeenPrunedUTXOHistory()>-1) throw exceptionDataPruned();
+    vector<string> results;
+    auto getAddressTxHistory=_stmtGetAddressTxHistory.lock();
+    getAddressTxHistory.bindText(1, address, SQLITE_STATIC);
+    getAddressTxHistory.bindText(2, address, SQLITE_STATIC);
+    while (getAddressTxHistory.executeStep() == SQLITE_ROW) {
+        Blob txid=getAddressTxHistory.getColumnBlob(0);
+        results.push_back(txid.toHex());
+    }
+    return results;
+}
+
+/**
+ * Returns a list of assets created by the specified address
+ * @param address
+ * @return
+ */
+std::vector<uint64_t> Database::getAssetsCreatedByAddress(const string& address) {
+    if (getBeenPrunedUTXOHistory()>-1) throw exceptionDataPruned();
+    vector<uint64_t> results;
+    auto getAssetCreateByAddress=_stmtGetAssetCreateByAddress.lock();
+    getAssetCreateByAddress.bindText(1, address, SQLITE_STATIC);
+    while (getAssetCreateByAddress.executeStep() == SQLITE_ROW) {
+        results.push_back(getAssetCreateByAddress.getColumnInt64(0));
+    }
+    return results;
 }
 
 /*
@@ -1369,13 +1471,12 @@ uint64_t Database::getTotalAssetCount(const string& assetId) const {
 ╚══════╝╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝ ╚═════╝ ╚══════╝     ╚══╝╚══╝ ╚═╝  ╚═╝   ╚═╝    ╚═════╝╚═╝  ╚═╝
  */
 
-bool Database::isWatchAddress(const string& address) const {
+bool Database::isWatchAddress(const string& address) {
     //if to many watch addresses to buffer effectively use database
     if (_exchangeWatchAddresses.empty()) {
-        int rc;
-        sqlite3_reset(_stmtIsWatchAddress);
-        sqlite3_bind_text(_stmtIsWatchAddress, 1, address.c_str(), address.length(), nullptr);
-        rc = executeSqliteStepWithRetry(_stmtIsWatchAddress);
+        auto isWatchAddress=_stmtIsWatchAddress.lock();
+        isWatchAddress.bindText(1, address, SQLITE_STATIC);
+        int rc = isWatchAddress.executeStep();
         return (rc == SQLITE_ROW);
     }
 
@@ -1391,10 +1492,9 @@ void Database::addWatchAddress(const string& address) {
     if (isWatchAddress(address)) return;
 
     //add to database
-    int rc;
-    sqlite3_reset(_stmtAddWatchAddress);
-    sqlite3_bind_text(_stmtAddWatchAddress, 1, address.c_str(), address.length(), nullptr);
-    rc = executeSqliteStepWithRetry(_stmtAddWatchAddress);
+    auto addWatchAddress=_stmtAddWatchAddress.lock();
+    addWatchAddress.bindText(1, address, SQLITE_STATIC);
+    int rc = addWatchAddress.executeStep();
     if (rc != SQLITE_OK) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedInsert();
@@ -1423,16 +1523,16 @@ void Database::addWatchAddress(const string& address) {
  * @param height
  * @return
  */
-vector<Database::exchangeRateHistoryValue> Database::getExchangeRatesAtHeight(unsigned int height) const {
+vector<Database::exchangeRateHistoryValue> Database::getExchangeRatesAtHeight(unsigned int height) {
     vector<exchangeRateHistoryValue> firstEntry;
-    sqlite3_reset(_stmtExchangeRatesAtHeight);
-    sqlite3_bind_int(_stmtExchangeRatesAtHeight, 1, height);
-    while (executeSqliteStepWithRetry(_stmtExchangeRatesAtHeight) == SQLITE_ROW) {
+    auto exchangeRatesAyHeight=_stmtExchangeRatesAtHeight.lock();
+    exchangeRatesAyHeight.bindInt( 1, height);
+    while (exchangeRatesAyHeight.executeStep() == SQLITE_ROW) {
         firstEntry.push_back(exchangeRateHistoryValue{
-                .height = (unsigned int) sqlite3_column_int(_stmtExchangeRatesAtHeight, 0),
-                .address = reinterpret_cast<const char*>(sqlite3_column_text(_stmtExchangeRatesAtHeight, 1)),
-                .index = (unsigned char) sqlite3_column_int(_stmtExchangeRatesAtHeight, 2),
-                .value = sqlite3_column_double(_stmtExchangeRatesAtHeight, 3)});
+                .height = (unsigned int) exchangeRatesAyHeight.getColumnInt(0),
+                .address = exchangeRatesAyHeight.getColumnText(1),
+                .index = (unsigned char) exchangeRatesAyHeight.getColumnInt(2),
+                .value = exchangeRatesAyHeight.getColumnDouble(3)});
     }
     return firstEntry;
 }
@@ -1441,13 +1541,12 @@ vector<Database::exchangeRateHistoryValue> Database::getExchangeRatesAtHeight(un
  * This function should only ever be called by the chain analyzer
  */
 void Database::addExchangeRate(const string& address, unsigned int index, unsigned int height, double exchangeRate) {
-    int rc;
-    sqlite3_reset(_stmtAddExchangeRate);
-    sqlite3_bind_text(_stmtAddExchangeRate, 1, address.c_str(), address.length(), SQLITE_STATIC);
-    sqlite3_bind_int(_stmtAddExchangeRate, 2, index);
-    sqlite3_bind_int(_stmtAddExchangeRate, 3, height);
-    sqlite3_bind_double(_stmtAddExchangeRate, 4, exchangeRate);
-    rc = executeSqliteStepWithRetry(_stmtAddExchangeRate);
+    auto addExchangeRate=_stmtAddExchangeRate.lock();
+    addExchangeRate.bindText(1, address, SQLITE_STATIC);
+    addExchangeRate.bindInt(2, index);
+    addExchangeRate.bindInt(3, height);
+    addExchangeRate.bindDouble(4, exchangeRate);
+    int rc = addExchangeRate.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedUpdate();
@@ -1464,24 +1563,28 @@ void Database::pruneExchange(unsigned int pruneHeight) {
     vector<exchangeRateHistoryValue> firstEntry=getExchangeRatesAtHeight(pruneHeight-1);
 
     //delete from exchange where pruneHeight<pruneHeight;
-    sqlite3_reset(_stmtPruneExchangeRate);
-    sqlite3_bind_int(_stmtPruneExchangeRate, 1, pruneHeight);
-    int rc = executeSqliteStepWithRetry(_stmtPruneExchangeRate);
-    if (rc != SQLITE_DONE) {
-        string tempErrorMessage = sqlite3_errmsg(_db);
-        throw exceptionFailedDelete();
+    {
+        auto pruneExchangeRate = _stmtPruneExchangeRate.lock();
+        pruneExchangeRate.bindInt(1, pruneHeight);
+        int rc = pruneExchangeRate.executeStep();
+        if (rc != SQLITE_DONE) {
+            string tempErrorMessage = sqlite3_errmsg(_db);
+            throw exceptionFailedDelete();
+        }
     }
 
     //mark blocks that can't be rolled back anymore
-    sqlite3_reset(_stmtRemoveNonReachable);
-    sqlite3_bind_int(_stmtRemoveNonReachable, 1, pruneHeight);
-    rc = executeSqliteStepWithRetry(_stmtRemoveNonReachable);
-    if (rc != SQLITE_DONE) {
-        string tempErrorMessage = sqlite3_errmsg(_db);
-        throw exceptionFailedUpdate();
+    {
+        auto removeNonReachable=_stmtRemoveNonReachable.lock();
+        removeNonReachable.bindInt(1, pruneHeight);
+        int rc = removeNonReachable.executeStep();
+        if (rc != SQLITE_DONE) {
+            string tempErrorMessage = sqlite3_errmsg(_db);
+            throw exceptionFailedUpdate();
+        }
     }
 
-    //add first valuessqlite3_bind_int back in to table
+    //add first values back in to table
     for (exchangeRateHistoryValue& kept: firstEntry) {
         addExchangeRate(kept.address, kept.index, kept.height, kept.value);
     }
@@ -1496,7 +1599,7 @@ void Database::pruneExchange(unsigned int pruneHeight) {
  * @param height
  * @return
  */
-double Database::getAcceptedExchangeRate(const ExchangeRate& rate, unsigned int height) const {
+double Database::getAcceptedExchangeRate(const ExchangeRate& rate, unsigned int height) {
     //see if there is an exchange rate or not
     if (!rate.enabled()) return 100000000;
 
@@ -1507,30 +1610,30 @@ double Database::getAcceptedExchangeRate(const ExchangeRate& rate, unsigned int 
     }
 
     //look up exchange rate
-    sqlite3_reset(_stmtGetValidExchangeRate);
-    sqlite3_bind_int(_stmtGetValidExchangeRate, 1, height);
-    sqlite3_bind_text(_stmtGetValidExchangeRate, 2, rate.address.c_str(), rate.address.length(), SQLITE_STATIC);
-    sqlite3_bind_int(_stmtGetValidExchangeRate, 3, rate.index);
+    auto getValidExchangeRate=_stmtGetValidExchangeRate.lock();
+    getValidExchangeRate.bindInt(1, height);
+    getValidExchangeRate.bindText(2, rate.address, SQLITE_STATIC);
+    getValidExchangeRate.bindInt(3, rate.index);
     double min = numeric_limits<double>::infinity();
-    while (executeSqliteStepWithRetry(_stmtGetValidExchangeRate) == SQLITE_ROW) {
+    while (getValidExchangeRate.executeStep() == SQLITE_ROW) {
         //check if smallest
-        double currentRate = sqlite3_column_double(_stmtGetValidExchangeRate, 0);
+        double currentRate = getValidExchangeRate.getColumnDouble(0);
         if (currentRate < min) min = currentRate;
 
         //check if that was the last sample(this test is done after the sample taken because we want to always get at least 1 sample past the expiry unless sample falls exactly on the expiry)
-        unsigned int sampleHeight = sqlite3_column_int(_stmtGetValidExchangeRate, 1);
+        unsigned int sampleHeight = getValidExchangeRate.getColumnInt(1);
         if (sampleHeight <= height - DigiAsset::EXCHANGE_RATE_LENIENCY) break;
-    };
+    }
     if (min == numeric_limits<double>::infinity()) throw out_of_range("Unknown Exchange Rate");
     return min;
 }
 
-double Database::getCurrentExchangeRate(const ExchangeRate& rate) const {
-    sqlite3_reset(_stmtGetCurrentExchangeRate);
-    sqlite3_bind_text(_stmtGetCurrentExchangeRate, 1, rate.address.c_str(), rate.address.length(), SQLITE_STATIC);
-    sqlite3_bind_int(_stmtGetCurrentExchangeRate, 2, rate.index);
-    if (executeSqliteStepWithRetry(_stmtGetCurrentExchangeRate) != SQLITE_ROW) throw out_of_range("Unknown Exchange Rate");
-    return sqlite3_column_double(_stmtGetCurrentExchangeRate, 0);
+double Database::getCurrentExchangeRate(const ExchangeRate& rate) {
+    auto getCurrentExchangeRate=_stmtGetCurrentExchangeRate.lock();
+    getCurrentExchangeRate.bindText(1, rate.address, SQLITE_STATIC);
+    getCurrentExchangeRate.bindInt(2, rate.index);
+    if (getCurrentExchangeRate.executeStep() != SQLITE_ROW) throw out_of_range("Unknown Exchange Rate");
+    return getCurrentExchangeRate.getColumnDouble(0);
 }
 
 /*
@@ -1544,15 +1647,14 @@ double Database::getCurrentExchangeRate(const ExchangeRate& rate) const {
 
 void Database::addKYC(const string& address, const string& country, const string& name, const string& hash,
                       unsigned int height) {
-    int rc;
-    sqlite3_reset(_stmtAddKYC);
+    auto addKYC = _stmtAddKYC.lock();
     Blob blobTXID = Blob(hash);
-    sqlite3_bind_text(_stmtAddKYC, 1, address.c_str(), address.length(), SQLITE_STATIC);
-    sqlite3_bind_text(_stmtAddKYC, 2, country.c_str(), country.length(), SQLITE_STATIC);
-    sqlite3_bind_text(_stmtAddKYC, 3, name.c_str(), name.length(), SQLITE_STATIC);
-    sqlite3_bind_blob(_stmtAddKYC, 4, blobTXID.data(), SHA256_LENGTH, SQLITE_STATIC);
-    sqlite3_bind_int(_stmtAddKYC, 5, height);
-    rc = executeSqliteStepWithRetry(_stmtAddKYC);
+    addKYC.bindText(1, address, SQLITE_STATIC);
+    addKYC.bindText(2, country, SQLITE_STATIC);
+    addKYC.bindText(3, name, SQLITE_STATIC);
+    addKYC.bindBlob(4, blobTXID, SQLITE_STATIC);
+    addKYC.bindInt(5, height);
+    int rc = addKYC.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedUpdate();
@@ -1560,35 +1662,33 @@ void Database::addKYC(const string& address, const string& country, const string
 }
 
 void Database::revokeKYC(const string& address, unsigned int height) {
-
-    int rc;
-    sqlite3_reset(_stmtRevokeKYC);
-    sqlite3_bind_int(_stmtRevokeKYC, 1, height);
-    sqlite3_bind_text(_stmtRevokeKYC, 2, address.c_str(), address.length(), SQLITE_STATIC);
-    rc = executeSqliteStepWithRetry(_stmtRevokeKYC);
+    auto revokeKYC=_stmtRevokeKYC.lock();
+    revokeKYC.bindInt(1, height);
+    revokeKYC.bindText(2, address, SQLITE_STATIC);
+    int rc = revokeKYC.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedUpdate();
     }
 }
 
-KYC Database::getAddressKYC(const string& address) const {
-    int rc;
-    sqlite3_reset(_stmtGetKYC);
-    sqlite3_bind_text(_stmtGetKYC, 1, address.c_str(), address.length(), SQLITE_STATIC);
-    rc = executeSqliteStepWithRetry(_stmtGetKYC);
+KYC Database::getAddressKYC(const string& address) {
+    auto getKYC=_stmtGetKYC.lock();
+    getKYC.bindText(1, address, SQLITE_STATIC);
+    int rc = getKYC.executeStep();
     if (rc != SQLITE_ROW) {
         return {
                 address};
     }
-    Blob hash(sqlite3_column_blob(_stmtGetKYC, 2), sqlite3_column_bytes(_stmtGetKYC, 2));
+    Blob hash=getKYC.getColumnBlob(2);
     return {
-            address,
-            reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetKYC, 0)),
-            reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetKYC, 1)),
-            hash.toHex(),
-            static_cast<unsigned int>(sqlite3_column_int(_stmtGetKYC, 3)),
-            sqlite3_column_int(_stmtGetKYC, 4)};
+        address,
+        getKYC.getColumnText(0),
+        getKYC.getColumnText(1),
+        hash.toHex(),
+        static_cast<unsigned int>(getKYC.getColumnInt(3)),
+        getKYC.getColumnInt(4)
+    };
 }
 
 /*
@@ -1604,14 +1704,13 @@ KYC Database::getAddressKYC(const string& address) const {
  * Records votes to database
  */
 void Database::addVote(const string& address, unsigned int assetIndex, uint64_t count, unsigned int height) {
-    int rc;
-    sqlite3_reset(_stmtAddVote);
-    sqlite3_bind_int(_stmtAddVote, 1, assetIndex);
-    sqlite3_bind_text(_stmtAddVote, 2, address.c_str(), address.length(), SQLITE_STATIC);
-    sqlite3_bind_int(_stmtAddVote, 3, height);
-    sqlite3_bind_int64(_stmtAddVote, 4, count);
-    sqlite3_bind_int64(_stmtAddVote, 5, count);
-    rc = executeSqliteStepWithRetry(_stmtAddVote);
+    auto addVote=_stmtAddVote.lock();
+    addVote.bindInt(1, assetIndex);
+    addVote.bindText(2, address, SQLITE_STATIC);
+    addVote.bindInt(3, height);
+    addVote.bindInt64(4, count);
+    addVote.bindInt64(5, count);
+    int rc = addVote.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedInsert();
@@ -1631,34 +1730,39 @@ void Database::pruneVote(unsigned int height) {
     };
 
     //we need to keep the sum of all votes we are pruning so lets add them up
-    int rc;
-    sqlite3_reset(_stmtGetVoteCount);
-    sqlite3_bind_int(_stmtGetVoteCount, 1, height);
     vector<entries> keep;
-    while (executeSqliteStepWithRetry(_stmtGetVoteCount) == SQLITE_ROW) {
-        keep.emplace_back(entries{
-                static_cast<unsigned int>(sqlite3_column_int(_stmtGetVoteCount, 0)),
-                reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetVoteCount, 1)),
-                static_cast<unsigned int>(sqlite3_column_int(_stmtGetVoteCount, 2)),
-                static_cast<unsigned int>(sqlite3_column_int(_stmtGetVoteCount, 3))});
+    {
+        auto getVoteCountAtHeight=_stmtGetVoteCountAtHeight.lock();
+        getVoteCountAtHeight.bindInt(1, height);
+        while (getVoteCountAtHeight.executeStep() == SQLITE_ROW) {
+            keep.emplace_back(entries{
+                    static_cast<unsigned int>(getVoteCountAtHeight.getColumnInt(0)),
+                    getVoteCountAtHeight.getColumnText(1),
+                    static_cast<unsigned int>(getVoteCountAtHeight.getColumnInt(2)),
+                    static_cast<unsigned int>(getVoteCountAtHeight.getColumnInt(3))});
+        }
     }
 
     //delete from votes where height<pruneHeight
-    sqlite3_reset(_stmtPruneVote);
-    sqlite3_bind_int(_stmtPruneVote, 1, height);
-    rc = executeSqliteStepWithRetry(_stmtPruneVote);
-    if (rc != SQLITE_DONE) {
-        string tempErrorMessage = sqlite3_errmsg(_db);
-        throw exceptionFailedDelete();
+    {
+        auto pruneVote = _stmtPruneVote.lock();
+        pruneVote.bindInt(1, height);
+        int rc = pruneVote.executeStep();
+        if (rc != SQLITE_DONE) {
+            string tempErrorMessage = sqlite3_errmsg(_db);
+            throw exceptionFailedDelete();
+        }
     }
 
     //mark blocks that can't be rolled back anymore
-    sqlite3_reset(_stmtRemoveNonReachable);
-    sqlite3_bind_int(_stmtRemoveNonReachable, 1, height);
-    rc = executeSqliteStepWithRetry(_stmtRemoveNonReachable);
-    if (rc != SQLITE_DONE) {
-        string tempErrorMessage = sqlite3_errmsg(_db);
-        throw exceptionFailedUpdate();
+    {
+        auto removeNonReachable = _stmtRemoveNonReachable.lock();
+        removeNonReachable.bindInt(1, height);
+        int rc = removeNonReachable.executeStep();
+        if (rc != SQLITE_DONE) {
+            string tempErrorMessage = sqlite3_errmsg(_db);
+            throw exceptionFailedUpdate();
+        }
     }
 
     //insert kept values
@@ -1670,6 +1774,24 @@ void Database::pruneVote(unsigned int height) {
 
     //set was pruned flag
     setBeenPrunedVoteHistory(height);
+}
+
+/**
+ * Returns current vote count
+ * @param assetIndex
+ * @return
+ */
+std::vector<VoteCount> Database::getVoteCounts(unsigned int assetIndex) {
+    auto getVoteCount=_stmtGetVoteCount.lock();
+    getVoteCount.bindInt(1, assetIndex);
+    vector<VoteCount> votes;
+    while (getVoteCount.executeStep() == SQLITE_ROW) {
+        votes.emplace_back(VoteCount{
+                getVoteCount.getColumnText(0),
+                static_cast<unsigned int>(getVoteCount.getColumnInt64(1)),
+        });
+    }
+    return votes;
 }
 
 /*
@@ -1704,12 +1826,12 @@ IPFSCallbackFunction& Database::getIPFSCallback(const string& callbackSymbol) {
  * @return
  */
 unsigned int Database::getIPFSJobCount() {
-    sqlite3_reset(_stmtNumberOfIPFSJobs);
-    int rc = executeSqliteStepWithRetry(_stmtNumberOfIPFSJobs);
+    auto numberOfIPFSJobs=_stmtNumberOfIPFSJobs.lock();
+    int rc = numberOfIPFSJobs.executeStep();
     if (rc != SQLITE_ROW) {
         throw exceptionFailedSelect();
     }
-    return sqlite3_column_int(_stmtNumberOfIPFSJobs, 0);
+    return numberOfIPFSJobs.getColumnInt(0);
 }
 
 /**
@@ -1751,31 +1873,31 @@ void Database::getNextIPFSJob(unsigned int& jobIndex, string& cid, string& sync,
 
         //clear from database
         if (removed) {
-            sqlite3_reset(_stmtClearIPFSPause);
-            sqlite3_bind_int64(_stmtClearIPFSPause, 1, currentTime);
-            int rc = executeSqliteStepWithRetry(_stmtClearIPFSPause);
+            auto clearIPFSPause=_stmtClearIPFSPause.lock();
+            clearIPFSPause.bindInt64(1, currentTime);
+            int rc = clearIPFSPause.executeStep();
             if (rc != SQLITE_DONE) throw exceptionFailedUpdate();
         }
     }
 
     //lookup the next job(if there is one)
-    sqlite3_reset(_stmtGetNextIPFSJob);
-    int rc = executeSqliteStepWithRetry(_stmtGetNextIPFSJob);
+    auto getNextIPFSJob=_stmtGetNextIPFSJob.lock();
+    int rc = getNextIPFSJob.executeStep();
     if (rc != SQLITE_ROW) {
         jobIndex = 0; //signal there are no new jobs
         return;
     }
-    jobIndex = sqlite3_column_int(_stmtGetNextIPFSJob, 0);
-    sync = reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetNextIPFSJob, 1));
-    cid = reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetNextIPFSJob, 2));
-    extra = reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetNextIPFSJob, 3));
-    string callbackSymbol = reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetNextIPFSJob, 4));
+    jobIndex = getNextIPFSJob.getColumnInt(0);
+    sync = getNextIPFSJob.getColumnText(1);
+    cid = getNextIPFSJob.getColumnText(2);
+    extra = getNextIPFSJob.getColumnText(3);
+    string callbackSymbol = getNextIPFSJob.getColumnText(4);
 
     //get max time
     uint64_t currentTime = std::chrono::duration_cast<std::chrono::milliseconds>(
                                    std::chrono::system_clock::now().time_since_epoch())
                                    .count();
-    uint64_t maxTime = sqlite3_column_int64(_stmtGetNextIPFSJob, 5);
+    uint64_t maxTime = getNextIPFSJob.getColumnInt64(5);
     if (maxTime == 0) {
         //if null return forever
         maxSleep = std::numeric_limits<unsigned int>::max();
@@ -1787,6 +1909,7 @@ void Database::getNextIPFSJob(unsigned int& jobIndex, string& cid, string& sync,
         maxSleep = maxTime - currentTime;
     }
 
+
     //look up callback function
     if (callbackSymbol == "_") {
         callbackSymbol += to_string(jobIndex);
@@ -1796,13 +1919,13 @@ void Database::getNextIPFSJob(unsigned int& jobIndex, string& cid, string& sync,
 
     //lock the sync if not pin or non synchronized
     if ((sync == "pin") || (sync == "_") || (sync.empty())) {
-        sqlite3_reset(_stmtSetIPFSLockJob);
-        sqlite3_bind_int(_stmtSetIPFSLockJob, 1, jobIndex);
-        rc = executeSqliteStepWithRetry(_stmtSetIPFSLockJob);
+        auto setIPFSLockJob=_stmtSetIPFSLockJob.lock();
+        setIPFSLockJob.bindInt(1, jobIndex);
+        rc = setIPFSLockJob.executeStep();
     } else {
-        sqlite3_reset(_stmtSetIPFSLockSync);
-        sqlite3_bind_text(_stmtSetIPFSLockSync, 1, sync.c_str(), sync.length(), SQLITE_STATIC);
-        rc = executeSqliteStepWithRetry(_stmtSetIPFSLockSync);
+        auto setIPFSLockSync=_stmtSetIPFSLockSync.lock();
+        setIPFSLockSync.bindText(1, sync, SQLITE_STATIC);
+        rc = setIPFSLockSync.executeStep();
     }
     if (rc != SQLITE_DONE) throw exceptionFailedUpdate();
 }
@@ -1817,15 +1940,15 @@ void Database::pauseIPFSSync(unsigned int jobIndex, const string& sync, unsigned
     //update database
     int rc;
     if ((sync == "pin") || (sync == "_") || (sync.empty())) { //handle jobs that are non ordered
-        sqlite3_reset(_stmtSetIPFSPauseJob);
-        sqlite3_bind_int64(_stmtSetIPFSPauseJob, 1, unpauseTime);
-        sqlite3_bind_int(_stmtSetIPFSPauseJob, 2, jobIndex);
-        rc = executeSqliteStepWithRetry(_stmtSetIPFSPauseJob);
+        auto setIPFSPauseJob=_stmtSetIPFSPauseJob.lock();
+        setIPFSPauseJob.bindInt64(1, unpauseTime);
+        setIPFSPauseJob.bindInt(2, jobIndex);
+        rc = setIPFSPauseJob.executeStep();
     } else {
-        sqlite3_reset(_stmtSetIPFSPauseSync);
-        sqlite3_bind_int64(_stmtSetIPFSPauseSync, 1, unpauseTime);
-        sqlite3_bind_text(_stmtSetIPFSPauseSync, 2, sync.c_str(), sync.length(), SQLITE_STATIC);
-        rc = executeSqliteStepWithRetry(_stmtSetIPFSPauseSync);
+        auto setIPFSPauseSync=_stmtSetIPFSPauseSync.lock();
+        setIPFSPauseSync.bindInt64(1, unpauseTime);
+        setIPFSPauseSync.bindText(2, sync, SQLITE_STATIC);
+        rc = setIPFSPauseSync.executeStep();
 
         //update ram
         if (rc == SQLITE_DONE) _ipfsCurrentlyPaused.emplace_back(sync, unpauseTime);
@@ -1845,19 +1968,23 @@ void Database::removeIPFSJob(unsigned int jobIndex, const string& sync) {
     std::lock_guard<std::mutex> lock(_mutexRemoveIPFSJob);
 
     //remove from database
-    sqlite3_reset(_stmtClearNextIPFSJob_a);
-    sqlite3_bind_int(_stmtClearNextIPFSJob_a, 1, jobIndex);
-    int rc = executeSqliteStepWithRetry(_stmtClearNextIPFSJob_a);
-    if (rc != SQLITE_DONE) { //there should always be one
-        string tempErrorMessage = sqlite3_errmsg(_db);
-        throw exceptionFailedSQLCommand(); //failed to delete or unlock
+    {
+        auto clearNextIPFSJob = _stmtClearNextIPFSJob_a.lock();
+        clearNextIPFSJob.bindInt(1, jobIndex);
+        int rc = clearNextIPFSJob.executeStep();
+        if (rc != SQLITE_DONE) { //there should always be one
+            string tempErrorMessage = sqlite3_errmsg(_db);
+            throw exceptionFailedSQLCommand(); //failed to delete or unlock
+        }
     }
-    sqlite3_reset(_stmtClearNextIPFSJob_b);
-    sqlite3_bind_text(_stmtClearNextIPFSJob_b, 1, sync.c_str(), sync.length(), SQLITE_STATIC);
-    rc = executeSqliteStepWithRetry(_stmtClearNextIPFSJob_b);
-    if (rc != SQLITE_DONE) { //there should always be one
-        string tempErrorMessage = sqlite3_errmsg(_db);
-        throw exceptionFailedSQLCommand(); //failed to delete or unlock
+    {
+        auto clearNextIPFSJob=_stmtClearNextIPFSJob_b.lock();
+        clearNextIPFSJob.bindText(1, sync, SQLITE_STATIC);
+        int rc = clearNextIPFSJob.executeStep();
+        if (rc != SQLITE_DONE) { //there should always be one
+            string tempErrorMessage = sqlite3_errmsg(_db);
+            throw exceptionFailedSQLCommand(); //failed to delete or unlock
+        }
     }
 
     //remove callback from ram if temp callback
@@ -1893,26 +2020,26 @@ Database::addIPFSJob(const string& cid, const string& sync, const string& extra,
     }
 
     //add type download to database
-    sqlite3_reset(_stmtInsertIPFSJob);
-    sqlite3_bind_text(_stmtInsertIPFSJob, 1, sync.c_str(), sync.length(), SQLITE_STATIC);
-    sqlite3_bind_text(_stmtInsertIPFSJob, 2, cid.c_str(), cid.length(), SQLITE_STATIC);
-    sqlite3_bind_text(_stmtInsertIPFSJob, 3, extra.c_str(), extra.length(), SQLITE_STATIC);
-    sqlite3_bind_text(_stmtInsertIPFSJob, 4, callbackSymbol.c_str(), callbackSymbol.length(), SQLITE_STATIC);
+    auto insertIPFSJob=_stmtInsertIPFSJob.lock();
+    insertIPFSJob.bindText(1, sync, SQLITE_STATIC);
+    insertIPFSJob.bindText(2, cid, SQLITE_STATIC);
+    insertIPFSJob.bindText(3, extra, SQLITE_STATIC);
+    insertIPFSJob.bindText(4, callbackSymbol, SQLITE_STATIC);
     if (pause != 0) {
-        sqlite3_bind_int64(_stmtInsertIPFSJob, 5, pause);
+        insertIPFSJob.bindInt64(5, pause);
     } else {
-        sqlite3_bind_null(_stmtInsertIPFSJob, 5);
+        insertIPFSJob.bindNull(5);
     }
     if (maxSleep == 0) {
-        sqlite3_bind_null(_stmtInsertIPFSJob, 6);
+        insertIPFSJob.bindNull(6);
     } else {
         uint64_t currentTime = std::chrono::duration_cast<std::chrono::milliseconds>(
                                        std::chrono::system_clock::now().time_since_epoch())
                                        .count();
-        sqlite3_bind_int64(_stmtInsertIPFSJob, 6, currentTime + maxSleep);
+        insertIPFSJob.bindInt64(6, currentTime + maxSleep);
     }
 
-    int rc = executeSqliteStepWithRetry(_stmtInsertIPFSJob);
+    int rc = insertIPFSJob.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedInsert();
@@ -1953,9 +2080,9 @@ promise<string> Database::addIPFSJobPromise(const string& cid, const string& syn
  */
 
 void Database::revokeDomain(const string& domain) {
-    sqlite3_reset(_stmtRevokeDomain);
-    sqlite3_bind_text(_stmtRevokeDomain, 1, domain.c_str(), domain.length(), SQLITE_STATIC);
-    int rc = executeSqliteStepWithRetry(_stmtRevokeDomain);
+    auto revokeDomain=_stmtRevokeDomain.lock();
+    revokeDomain.bindText(1, domain, SQLITE_STATIC);
+    int rc = revokeDomain.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedUpdate();
@@ -1963,26 +2090,26 @@ void Database::revokeDomain(const string& domain) {
 }
 
 void Database::addDomain(const string& domain, const string& assetId) {
-    sqlite3_reset(_stmtAddDomain);
-    sqlite3_bind_text(_stmtAddDomain, 1, domain.c_str(), domain.length(), SQLITE_STATIC);
-    sqlite3_bind_text(_stmtAddDomain, 2, assetId.c_str(), assetId.length(), SQLITE_STATIC);
-    int rc = executeSqliteStepWithRetry(_stmtAddDomain);
+    auto addDomain=_stmtAddDomain.lock();
+    addDomain.bindText(1, domain, SQLITE_STATIC);
+    addDomain.bindText(2, assetId, SQLITE_STATIC);
+    int rc = addDomain.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedUpdate();
     }
 }
 
-string Database::getDomainAssetId(const std::string& domain, bool returnErrorIfRevoked) const {
-    sqlite3_reset(_stmtGetDomainAssetId);
-    sqlite3_bind_text(_stmtGetDomainAssetId, 1, domain.c_str(), domain.length(), SQLITE_STATIC);
-    int rc = executeSqliteStepWithRetry(_stmtGetDomainAssetId);
+string Database::getDomainAssetId(const std::string& domain, bool returnErrorIfRevoked) {
+    auto getDomainAssetId=_stmtGetDomainAssetId.lock();
+    getDomainAssetId.bindText(1, domain, SQLITE_STATIC);
+    int rc = getDomainAssetId.executeStep();
 
     if (rc != SQLITE_ROW) throw DigiByteDomain::exceptionUnknownDomain();
-    if (returnErrorIfRevoked && (sqlite3_column_int(_stmtGetDomainAssetId, 1) == true)) {
+    if (returnErrorIfRevoked && (getDomainAssetId.getColumnInt(1) == true)) {
         throw DigiByteDomain::exceptionRevokedDomain();
     }
-    return reinterpret_cast<const char*>(sqlite3_column_text(_stmtGetDomainAssetId, 0));
+    return getDomainAssetId.getColumnText(0);
 }
 
 bool Database::isMasterDomainAssetId(const std::string& assetId) const {
@@ -1997,17 +2124,19 @@ bool Database::isActiveMasterDomainAssetId(const std::string& assetId) const {
 }
 
 void Database::setMasterDomainAssetId(const string& assetId) {
-    sqlite3_reset(_stmtSetDomainMasterAssetId_a);
-    string lastDomain = _masterDomainAssetId.back();
-    sqlite3_bind_text(_stmtSetDomainMasterAssetId_a, 1, lastDomain.c_str(), lastDomain.length(), SQLITE_STATIC);
-    int rc = executeSqliteStepWithRetry(_stmtSetDomainMasterAssetId_a);
-    if (rc != SQLITE_DONE) {
-        string tempErrorMessage = sqlite3_errmsg(_db);
-        throw exceptionFailedUpdate();
+    {
+        auto setDomainMasterAssetId = _stmtSetDomainMasterAssetId_a.lock();
+        string lastDomain = _masterDomainAssetId.back();
+        setDomainMasterAssetId.bindText(1, lastDomain, SQLITE_STATIC);
+        int rc = setDomainMasterAssetId.executeStep();
+        if (rc != SQLITE_DONE) {
+            string tempErrorMessage = sqlite3_errmsg(_db);
+            throw exceptionFailedUpdate();
+        }
     }
-    sqlite3_reset(_stmtSetDomainMasterAssetId_b);
-    sqlite3_bind_text(_stmtSetDomainMasterAssetId_b, 1, assetId.c_str(), assetId.length(), SQLITE_STATIC);
-    rc = executeSqliteStepWithRetry(_stmtSetDomainMasterAssetId_b);
+    auto setDomainMasterAssetId=_stmtSetDomainMasterAssetId_b.lock();
+    setDomainMasterAssetId.bindText(1, assetId, SQLITE_STATIC);
+    int rc = setDomainMasterAssetId.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedInsert();
@@ -2023,7 +2152,7 @@ bool Database::isDomainCompromised() const {
     return (_masterDomainAssetId.back().empty());
 }
 
-std::string Database::getDomainAddress(const string& domain) const {
+std::string Database::getDomainAddress(const string& domain) {
     string assetId = getDomainAssetId(domain);
     uint64_t assetIndex = getAssetIndex(assetId);
     vector<AssetHolder> holders = getAssetHolders(assetIndex);
@@ -2055,17 +2184,19 @@ int Database::defaultCallback(void* NotUsed, int argc, char** argv, char** azCol
 */
 void Database::repinPermanent(unsigned int poolIndex) {
     //repin all asset main meta data
-    sqlite3_reset(_stmtRepinAssets);
-    int rc = executeSqliteStepWithRetry(_stmtRepinAssets);
-    if (rc != SQLITE_DONE) {
-        string tempErrorMessage = sqlite3_errmsg(_db);
-        throw exceptionFailedInsert();
+    {
+        auto repinAssets = _stmtRepinAssets.lock();
+        int rc = repinAssets.executeStep();
+        if (rc != SQLITE_DONE) {
+            string tempErrorMessage = sqlite3_errmsg(_db);
+            throw exceptionFailedInsert();
+        }
     }
 
     //repin all files that are part of specific pool
-    sqlite3_reset(_stmtRepinPermanentSpecific);
-    sqlite3_bind_int(_stmtRepinPermanentSpecific, 1, poolIndex);
-    rc = executeSqliteStepWithRetry(_stmtRepinPermanentSpecific);
+    auto repinPermanentSpecific=_stmtRepinPermanentSpecific.lock();
+    repinPermanentSpecific.bindInt(1, poolIndex);
+    int rc = repinPermanentSpecific.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedInsert();
@@ -2100,7 +2231,7 @@ void Database::unpinPermanent(unsigned int poolIndex) {
     sql += ";";
 
 
-    int rc = sqlite3_exec(_db, sql.c_str(), Database::defaultCallback, 0, nullptr);
+    int rc = sqlite3_exec(_db, sql.c_str(), Database::defaultCallback, nullptr, nullptr);
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedInsert();
@@ -2113,10 +2244,10 @@ void Database::unpinPermanent(unsigned int poolIndex) {
 */
 void Database::addToPermanent(unsigned int poolIndex, const string& cid) {
     if (cid.empty()) return;
-    sqlite3_reset(_stmtInsertPermanent);
-    sqlite3_bind_text(_stmtInsertPermanent, 1, cid.c_str(), cid.length(), SQLITE_STATIC);
-    sqlite3_bind_int(_stmtInsertPermanent, 2, poolIndex);
-    int rc = executeSqliteStepWithRetry(_stmtInsertPermanent);
+    auto insertPermanent=_stmtInsertPermanent.lock();
+    insertPermanent.bindText(1, cid, SQLITE_STATIC);
+    insertPermanent.bindInt(2, poolIndex);
+    int rc = insertPermanent.executeStep();
     if (rc != SQLITE_DONE) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         throw exceptionFailedInsert();
@@ -2125,28 +2256,31 @@ void Database::addToPermanent(unsigned int poolIndex, const string& cid) {
 
 void Database::removeFromPermanent(unsigned int poolIndex, const std::string& cid, bool unpin) {
     //remove from database
-    sqlite3_reset(_stmtDeletePermanent);
-    sqlite3_bind_text(_stmtDeletePermanent, 1, cid.c_str(), -1, SQLITE_TRANSIENT);
-    sqlite3_bind_int(_stmtDeletePermanent, 2, poolIndex);
+    {
+        auto deletePermanent=_stmtDeletePermanent.lock();
+        deletePermanent.bindText(1, cid, SQLITE_TRANSIENT);
+        deletePermanent.bindInt(2, poolIndex);
+        deletePermanent.executeStep();
+    }
 
     //unpin if not in database anymore
     if (!unpin) return;
 
     //see if asset still present
-    sqlite3_reset(_stmtIsInPermanent);
-    sqlite3_bind_text(_stmtIsInPermanent, 1, cid.c_str(), -1, SQLITE_TRANSIENT);
-    if (sqlite3_step(_stmtIsAssetInAPool) == SQLITE_ROW) return;
+    auto isInPermanent=_stmtIsInPermanent.lock();
+    isInPermanent.bindText(1, cid, SQLITE_TRANSIENT);
+    if (isInPermanent.executeStep() == SQLITE_ROW) return;
 
     //add asset to be unpinned
     addIPFSJob(cid, "unpin");
 }
 
 void Database::addAssetToPool(unsigned int poolIndex, unsigned int assetIndex) {
-    sqlite3_reset(_stmtAddAssetToPool);
-    sqlite3_bind_int(_stmtAddAssetToPool, 1, assetIndex);
-    sqlite3_bind_int(_stmtAddAssetToPool, 2, poolIndex);
+    auto addAssetToPool=_stmtAddAssetToPool.lock();
+    addAssetToPool.bindInt(1, assetIndex);
+    addAssetToPool.bindInt(2, poolIndex);
 
-    if (sqlite3_step(_stmtAddAssetToPool) != SQLITE_DONE) {
+    if (addAssetToPool.executeStep() != SQLITE_DONE) {
         throw exceptionFailedInsert();
     }
 }
@@ -2154,28 +2288,33 @@ void Database::addAssetToPool(unsigned int poolIndex, unsigned int assetIndex) {
 void Database::removeAssetFromPool(unsigned int poolIndex, const std::string& assetId, bool unpin) {
     //make list of assetIndex we will remove and there cid
     vector<pair<unsigned int, string>> toDelete;
-    sqlite3_reset(_stmtPSPFindBadAsset);
-    sqlite3_bind_text(_stmtPSPFindBadAsset, 1, assetId.c_str(), -1, SQLITE_TRANSIENT);
-    sqlite3_bind_int(_stmtPSPFindBadAsset, 2, poolIndex);
-    while (sqlite3_step(_stmtPSPFindBadAsset) == SQLITE_ROW) {
-        unsigned int assetIndex = sqlite3_column_int(_stmtPSPFindBadAsset, 0);
-        string cid = reinterpret_cast<const char*>(sqlite3_column_text(_stmtPSPFindBadAsset, 1));
-        toDelete.emplace_back(make_pair(assetIndex, cid));
+    {
+        auto pspFindBadAsset=_stmtPSPFindBadAsset.lock();
+        pspFindBadAsset.bindText(1, assetId, SQLITE_TRANSIENT);
+        pspFindBadAsset.bindInt(2, poolIndex);
+        while (pspFindBadAsset.executeStep() == SQLITE_ROW) {
+            unsigned int assetIndex = pspFindBadAsset.getColumnInt(0);
+            string cid = pspFindBadAsset.getColumnText(1);
+            toDelete.emplace_back(make_pair(assetIndex, cid));
+        }
     }
 
     //remove from database
-    sqlite3_reset(_stmtPSPDeleteBadAsset);
-    sqlite3_bind_text(_stmtPSPDeleteBadAsset, 1, assetId.c_str(), -1, SQLITE_TRANSIENT);
-    sqlite3_bind_int(_stmtPSPDeleteBadAsset, 2, poolIndex);
+    {
+        auto pspDeleteBadAsset=_stmtPSPDeleteBadAsset.lock();
+        pspDeleteBadAsset.bindText(1, assetId, SQLITE_TRANSIENT);
+        pspDeleteBadAsset.bindInt(2, poolIndex);
+        pspDeleteBadAsset.executeStep();
+    }
 
     //unpin if not in database anymore
     if (!unpin) return;
     for (auto pair: toDelete) {
         //see if asset still present
         unsigned int assetIndex = pair.first;
-        sqlite3_reset(_stmtIsAssetInAPool);
-        sqlite3_bind_int(_stmtIsAssetInAPool, 1, assetIndex);
-        if (sqlite3_step(_stmtIsAssetInAPool) == SQLITE_ROW) continue;
+        auto isAssetInAPool=_stmtIsAssetInAPool.lock();
+        isAssetInAPool.bindInt(1, assetIndex);
+        if (isAssetInAPool.executeStep() == SQLITE_ROW) continue;
 
         //add asset to be unpinned
         addIPFSJob(pair.second, "unpin");
@@ -2183,12 +2322,12 @@ void Database::removeAssetFromPool(unsigned int poolIndex, const std::string& as
 }
 
 bool Database::isAssetInPool(unsigned int poolIndex, unsigned int assetIndex) {
-    sqlite3_reset(_stmtIsAssetInPool);
-    sqlite3_bind_int(_stmtIsAssetInPool, 1, assetIndex);
-    sqlite3_bind_int(_stmtIsAssetInPool, 2, poolIndex);
+    auto isAssetInPool=_stmtIsAssetInPool.lock();
+    isAssetInPool.bindInt(1, assetIndex);
+    isAssetInPool.bindInt(2, poolIndex);
 
-    if (sqlite3_step(_stmtIsAssetInPool) == SQLITE_ROW) {
-        return sqlite3_column_int(_stmtIsAssetInPool, 0) > 0;
+    if (isAssetInPool.executeStep() == SQLITE_ROW) {
+        return isAssetInPool.getColumnInt(0) > 0;
     } else {
         throw exceptionFailedSelect();
     }
@@ -2231,7 +2370,7 @@ void Database::updateStats(unsigned int timeFrame) {
     unsigned int startTime = 0;
     unsigned int beginHeight = 1;
     sql = "SELECT end_time,begin_height FROM StatsCutOffHeights_" + timeStr + " ORDER BY end_time DESC LIMIT 1;";
-    rc = sqlite3_prepare_v2(_db, sql.c_str(), -1, &stmt, 0);
+    rc = sqlite3_prepare_v2(_db, sql.c_str(), -1, &stmt, nullptr);
     if (rc == SQLITE_OK) {
         //table exists so get the highest value
         rc = executeSqliteStepWithRetry(stmt);
@@ -2355,7 +2494,7 @@ executeSQLStatement(
     "FROM ( "
         "SELECT "
             "tch.end_time, "
-            "COUNT(DISTINCT u.address) AS num_addresses_with_assets "
+            "COUNT(DISPERSED u.address) AS num_addresses_with_assets "
         "FROM utxos u "
         "JOIN StatsCutOffHeights_" + timeStr + " tch ON u.heightCreated <= tch.end_height AND (u.heightDestroyed IS NULL OR u.heightDestroyed > tch.end_height) "
         "WHERE u.assetIndex > 1 "
@@ -2374,7 +2513,7 @@ executeSQLStatement(
     "FROM ( "
         "SELECT "
             "tch.end_time, "
-            "COUNT(DISTINCT u.address) AS num_addresses_created "
+            "COUNT(DISPERSED u.address) AS num_addresses_created "
         "FROM StatsCutOffHeights_" + timeStr + " tch "
         "LEFT JOIN ( "
             "SELECT "
@@ -2398,7 +2537,7 @@ executeSQLStatement(
     "FROM ( "
         "SELECT "
             "tch.end_time, "
-            "COUNT(DISTINCT u.address) AS num_addresses_used "
+            "COUNT(DISPERSED u.address) AS num_addresses_used "
         "FROM StatsCutOffHeights_" + timeStr + " tch "
         "LEFT JOIN utxos u ON u.heightDestroyed >= tch.begin_height AND u.heightDestroyed <= tch.end_height "
         "GROUP BY tch.end_time "
@@ -2416,7 +2555,7 @@ executeSQLStatement(
     "FROM ( "
         "SELECT "
             "tch.end_time, "
-            "COUNT(DISTINCT u.address) AS total_addresses "
+            "COUNT(DISPERSED u.address) AS total_addresses "
         "FROM StatsCutOffHeights_" + timeStr + " tch "
         "LEFT JOIN utxos u ON u.heightCreated <= tch.end_height "
         "GROUP BY tch.end_time "
@@ -2434,7 +2573,7 @@ executeSQLStatement(
     "FROM ( "
         "SELECT "
             "tch.end_time, "
-            "COUNT(DISTINCT u.address) AS num_quantum_unsafe "
+            "COUNT(DISPERSED u.address) AS num_quantum_unsafe "
         "FROM StatsCutOffHeights_" + timeStr + " tch "
         "LEFT JOIN ("
             "SELECT u.address, tch_inner.end_height "
@@ -2462,7 +2601,7 @@ std::vector<AlgoStats> Database::getAlgoStats(unsigned int start, unsigned int e
     std::vector<AlgoStats> algoStatsList;
     sqlite3_stmt* stmt;
     std::string sql = "SELECT * FROM StatsAlgo_" + std::to_string(timeFrame) + " WHERE end_time >= ? AND end_time <= ? ORDER BY end_time ASC, algo ASC";
-    if (sqlite3_prepare_v2(_db, sql.c_str(), -1, &stmt, 0) != SQLITE_OK) {
+    if (sqlite3_prepare_v2(_db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
         throw exceptionCreatingStatement();
     }
     sqlite3_bind_int(stmt, 1, start);
@@ -2494,7 +2633,7 @@ std::vector<AddressStats> Database::getAddressStats(unsigned int start, unsigned
     std::vector<AddressStats> addressStatsList;
     sqlite3_stmt* stmt;
     std::string sql = "SELECT * FROM StatsAddress_" + std::to_string(timeFrame) + " WHERE end_time >= ? AND end_time <= ? ORDER BY end_time ASC";
-    if (sqlite3_prepare_v2(_db, sql.c_str(), -1, &stmt, 0) != SQLITE_OK) {
+    if (sqlite3_prepare_v2(_db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
         throw exceptionCreatingStatement();
     }
     sqlite3_bind_int(stmt, 1, start);
@@ -2547,7 +2686,7 @@ int Database::executeSqliteStepWithRetry(sqlite3_stmt* stmt, int maxRetries, int
 void Database::executeSQLStatement(const string& query, const std::exception& errorToThrowOnFail) {
     int rc;
     sqlite3_stmt* stmt;
-    rc = sqlite3_prepare_v2(_db, query.c_str(), -1, &stmt, 0);
+    rc = sqlite3_prepare_v2(_db, query.c_str(), -1, &stmt, nullptr);
     if (rc != SQLITE_OK) {
         string tempErrorMessage = sqlite3_errmsg(_db);
         sqlite3_finalize(stmt);

--- a/src/Database.h
+++ b/src/Database.h
@@ -344,7 +344,7 @@ public:
     std::vector<std::string> getAssetTxHistory(const std::string& assetId);
 
     //utxo table address related
-    std::vector<AssetUTXO> getAddressUTXOs(const std::string& address);
+    std::vector<AssetUTXO> getAddressUTXOs(const std::string& address, unsigned int minConfirms=0, unsigned int maxConfrims=std::numeric_limits<unsigned int>::max());
     std::vector<std::string> getAddressTxList(const std::string& address);
     std::vector<uint64_t> getAssetsCreatedByAddress(const std::string& address);
 

--- a/src/DigiAsset.cpp
+++ b/src/DigiAsset.cpp
@@ -316,7 +316,7 @@ DigiAsset::DigiAsset(uint64_t assetIndex, const string& assetId, const string& c
             _aggregation = AGGREGABLE;
             break;
         case 'd':
-            _aggregation = DISTINCT;
+            _aggregation = DISPERSED;
             break;
         case 'h':
             _aggregation = HYBRID;
@@ -618,6 +618,7 @@ std::string DigiAsset::getCID() const {
  * 1 and up - assetIndex.  This value is only valid on this particular node.
  */
 uint64_t DigiAsset::getAssetIndex() const {
+    if (_assetIndex==0) throw exceptionUnknownAssetIndex();
     return _assetIndex;
 }
 
@@ -632,7 +633,7 @@ void DigiAsset::setAssetIndex(uint64_t assetIndex) {
 
 /**
  * Returns if hybrid asset
- * Hybrid is like a mixture of aggregable and distinct.  You can create multiple chunks of assets each chunk being a sub
+ * Hybrid is like a mixture of aggregable and dispersed.  You can create multiple chunks of assets each chunk being a sub
  * asset.  As you send assets they can be split up and tracked but they don't recombine to save space like aggregable assets do.
  */
 bool DigiAsset::isHybrid() const {
@@ -649,13 +650,13 @@ bool DigiAsset::isAggregable() const {
 }
 
 /**
- * Returns if the asset is distinct
- * Distinct assets can be individually tracked through the chain.
+ * Returns if the asset is dispersed
+ * Dispersed assets can be individually tracked through the chain.
  * Under most circumstances you would want them to be unlocked and issued 1 at a time so each is unique but all share the
  * same assetId.  assetIndex is used internally to tell them apart
  */
-bool DigiAsset::isDistinct() const {
-    return (_aggregation == DISTINCT);
+bool DigiAsset::isDispersed() const {
+    return (_aggregation == DISPERSED);
 }
 
 /**
@@ -1003,4 +1004,17 @@ Value DigiAsset::toJSON(bool simplified) const {
     result["issuer"] = kycObj;
 
     return result;
+}
+
+/**
+ * when loading already existing assets use this command to lookup assetIndex.
+ * Will do nothing if already known
+ */
+void DigiAsset::lookupAssetIndex(const string& txid, unsigned int vout) {
+    if (_assetIndex>0) return;
+    Database* db=AppMain::GetInstance()->getDatabase();
+    _assetIndex=db->getAssetIndex(_assetId,txid,vout);
+}
+bool DigiAsset::isAssetIndexSet() const {
+    return _assetIndex!=0;
 }

--- a/src/DigiAsset.h
+++ b/src/DigiAsset.h
@@ -63,7 +63,7 @@ public:
     static const unsigned int EXCHANGE_RATE_LENIENCY = 240; //number of blocks off exchange rate can be and still be excepted
     static const unsigned char AGGREGABLE = 0;
     static const unsigned char HYBRID = 1;
-    static const unsigned char DISTINCT = 2;
+    static const unsigned char DISPERSED = 2;
 
     static const ExchangeRate standardExchangeRates[];
     static const size_t standardExchangeRatesCount = 20;
@@ -96,6 +96,8 @@ public:
     uint8_t getDecimals() const;
 
     uint64_t getAssetIndex() const;
+    bool isAssetIndexSet() const;
+    void lookupAssetIndex(const std::string& txid, unsigned int vout);
     void setAssetIndex(uint64_t assetIndex);
     std::string getAssetId() const;
     std::string getCID() const;
@@ -109,7 +111,7 @@ public:
 
     bool isHybrid() const;
     bool isAggregable() const;
-    bool isDistinct() const;
+    bool isDispersed() const;
     bool isLocked() const;
 
     //functions that can only be used on assets we own and can be edited(or new assets not on chain)
@@ -160,6 +162,14 @@ public:
     public:
         char* what() {
             _lastErrorMessage = "Asset value is write protected"; //running setOwned may fix problem if it doesn't value can not be changed
+            return const_cast<char*>(_lastErrorMessage.c_str());
+        }
+    };
+
+    class exceptionUnknownAssetIndex : public exception {
+    public:
+        char* what() {
+            _lastErrorMessage = "The asset has either not been added to database yet or have not looked it up yet"; //running setOwned may fix problem if it doesn't value can not be changed
             return const_cast<char*>(_lastErrorMessage.c_str());
         }
     };

--- a/src/DigiAssetTypes.cpp
+++ b/src/DigiAssetTypes.cpp
@@ -6,9 +6,25 @@
 #include <vector>
 #include "DigiAssetTypes.h"
 #include "serialize.h"
+#include "DigiAsset.h"
 
 
 using namespace std;
+
+Json::Value AssetUTXO::toJSON(bool simplified) const {
+    Json::Value jsonUTXO;
+    jsonUTXO["txid"] = txid;
+    jsonUTXO["vout"] = vout;
+    jsonUTXO["address"] = address;
+    jsonUTXO["digibyte"] = static_cast<Json::UInt64>(digibyte);
+
+    // Convert assets if present
+    for (const auto& asset : assets) {
+        jsonUTXO["assets"].append(asset.toJSON(simplified));
+    }
+
+    return jsonUTXO;
+}
 
 void serialize(vector<uint8_t>& serializedData, const Signer& input) {
     serialize(serializedData, input.address);

--- a/src/DigiAssetTypes.h
+++ b/src/DigiAssetTypes.h
@@ -7,6 +7,7 @@
 
 
 #include <cstdint>
+#include <jsoncpp/json/value.h>
 #include <string>
 
 class DigiAsset; //forward declaration
@@ -22,6 +23,8 @@ struct AssetUTXO {
     std::string address;
     uint64_t digibyte; //in sats
     std::vector<DigiAsset> assets;
+
+    Json::Value toJSON(bool simplified = true) const;
 };
 
 struct Signer {

--- a/src/DigiByteCore.h
+++ b/src/DigiByteCore.h
@@ -64,6 +64,8 @@ public:
     std::string getBlockHash(uint height);
     blockinfo_t getBlock(const std::string& hash);
     getrawtransaction_t getRawTransaction(const std::string& txid);
+    std::vector<unspenttxout_t> listUnspent(int minconf = 1, int maxconf = 99999999, const std::vector<std::string>& addresses={});
+    getaddressinfo_t getAddressInfo(const std::string& address);
 
 
     /* === Auxiliary functions === */
@@ -146,7 +148,7 @@ public:
     utxoinfo_t gettxout(const std::string& txid, int n, bool includemempool = true);
     utxosetinfo_t gettxoutsetinfo();
 
-    std::vector<unspenttxout_t> listunspent(int minconf = 1, int maxconf = 999999);
+    std::vector<unspenttxout_t> listunspent(int minconf = 1, int maxconf = 99999999, const std::vector<std::string>& addresses={});
     std::vector<txout_t> listlockunspent();
     bool lockunspent(bool unlock, const std::vector<txout_t>& outputs);
 

--- a/src/DigiByteCore_Types.h
+++ b/src/DigiByteCore_Types.h
@@ -78,6 +78,16 @@ struct addressinfo_t : accountinfo_t {
     std::vector<std::string> txids;
 };
 
+struct getaddressinfo_t {
+    std::string address;
+    std::string scriptPubKey;
+    bool ismine;
+    bool iswatchonly;
+    bool isscript;
+    bool iswitness;
+    std::vector<std::string> labels;
+};
+
 struct transactioninfo_t : accountinfo_t {
     std::string address;
     std::string category;

--- a/src/DigiByteTransaction.h
+++ b/src/DigiByteTransaction.h
@@ -64,6 +64,7 @@ public:
     DigiByteTransaction(const std::string& txid, unsigned int height = 0);
 
     void addToDatabase();
+    void lookupAssetIndexes();
 
     bool isStandardTransaction() const;
 

--- a/src/OldStream.cpp
+++ b/src/OldStream.cpp
@@ -1,0 +1,845 @@
+//
+// Created by mctrivia on 24/02/24.
+//
+
+#include "OldStream.h"
+#include "AppMain.h"
+#include "Database.h"
+#include "Log.h"
+#include <jsonrpccpp/client.h>
+#include <jsonrpccpp/client/connectors/httpclient.h>
+#include <set>
+#include <unordered_map>
+
+using namespace std;
+
+namespace OldStream {
+
+    /**
+     * Retrieves transaction data for a given transaction ID.
+     * This is a clone of the getrawtransaction with verbose set to true use getrawtransaction instead.
+     *
+     *
+     * @param txid The transaction ID to fetch data for.
+     * @return Json::Value containing TxData with the following structure:
+     * {
+     *   "txid": string, // The transaction ID
+     *   "vin": [ // An array of input objects, each Vin object contains:
+     *     {
+     *       "sequence": int, // The sequence number of the input
+     *       "coinbase": string, // A coinbase transaction identifier (only present in coinbase transactions)
+     *       "txid": string, // The transaction ID of the source transaction for this input (not present in coinbase transactions)
+     *       "vout": int, // The output index in the source transaction (not present in coinbase transactions)
+     *       "scriptSig": { // The scriptSig object contains:
+     *         "asm": string, // Assembly notation of the script
+     *         "hex": string // Hexadecimal representation of the script
+     *       },
+     *       "scriptPubKey": { // Optional, the scriptPubKey object related to the input, contains:
+     *         "asm": string, // Assembly notation of the script
+     *         "hex": string, // Hexadecimal representation of the script
+     *         "reqSigs": int, // Number of required signatures
+     *         "type": string, // Type of script (e.g., 'pubkeyhash')
+     *         "addresses": [string] // Array of addresses involved in the transaction
+     *       },
+     *       "assets": [ // Optional, present if assets are involved in the input, each AssetCount object contains:
+     *         {
+     *           "assetId": string, // The asset ID
+     *           "amount": string|BigInt, // The amount of the asset
+     *           "decimals": int, // Decimals for the asset amount
+     *           "cid": string, // Content identifier, present only for non-aggregable assets
+     *           "rules": boolean // Rules applied to the asset, true or undefined
+     *         }
+     *       ]
+     *     }
+     *   ],
+     *   "vout": [ // An array of output objects, each Vout object contains:
+     *     {
+     *       "value": string|BigInt, // The value of the output in satoshis or asset units
+     *       "vout": int, // The index of this output in the transaction
+     *       "scriptPubKey": { // The scriptPubKey object contains:
+     *         "asm": string, // Assembly notation of the script
+     *         "hex": string, // Hexadecimal representation of the script
+     *         "reqSigs": int, // Number of required signatures
+     *         "type": string, // Type of script (e.g., 'pubkeyhash')
+     *         "addresses": [string] // Array of addresses involved in the transaction
+     *       },
+     *       "spent": int, // The height at which the output was spent (optional)
+     *       "assets": [ // Optional, present if assets are involved in the output, same structure as assets in "vin"
+     *       ]
+     *     }
+     *   ],
+     *   "blockhash": string, // The hash of the block containing this transaction
+     *   "height": int, // The height of the block containing this transaction
+     *   "time": int // The time the transaction was included in a block
+     * }
+     */
+    Json::Value getTxData(const std::string& txid) {
+        //get what core wallet has to say
+        Value params=Json::arrayValue;
+        params.append(txid);
+        params.append(true);
+        Value rawTransactionData = AppMain::GetInstance()->getDigiByteCore()->sendcommand("getrawtransaction", params);
+
+        //load transaction
+        DigiByteTransaction tx{txid};
+
+        //convert to a value and return
+        tx.lookupAssetIndexes();
+        return tx.toJSON(rawTransactionData);
+    }
+
+    /**
+     * Fetches data for a DigiByte block by its hash
+     *
+     * @param hash The hash of the block to fetch.
+     * @return Json::Value containing DigiByteBlockData with the following structure:
+     * {
+     *   "hash": string, // The block hash
+     *   "strippedsize": int, // The size of the block excluding witness data
+     *   "size": int, // The total size of the block
+     *   "weight": int, // The block weight as defined in BIP 141
+     *   "height": int, // The block height
+     *   "version": int, // The block version
+     *   "pow_algo_id": int, // The proof-of-work algorithm identifier
+     *   "time": int, // The block time in seconds since the epoch
+     *   "mediantime": int, // cheated and just copied time value here for backwards compatability
+     *   "difficulty": Number, // The difficulty target of the block
+     *   "nTx": int, // The number of transactions in the block
+     *   "previousblockhash": string, // The hash of the previous block
+     *   "nextblockhash": string, // The hash of the next block (optional, may not be present)
+     *   "tx": [ // An array of transactions in the block, each TxData object contains:
+     *     {
+     *       "txid": string, // The transaction ID
+     *       "vin": [ // An array of input objects, each Vin object contains:
+     *         {
+     *           "sequence": int,
+     *           "coinbase": string, // Present only for coinbase transactions
+     *           "txid": string, // The transaction ID of the source transaction for this input
+     *           "vout": int, // The output index in the source transaction
+     *           "scriptSig": { // The scriptSig object contains:
+     *             "asm": string, // Assembly notation of the script
+     *             "hex": string // Hexadecimal representation of the script
+     *           },
+     *           "scriptPubKey": { // The scriptPubKey object, only present if relevant, contains:
+     *             "asm": string,
+     *             "hex": string,
+     *             "reqSigs": int, // Number of required signatures
+     *             "type": string, // Type of script (e.g., 'pubkeyhash')
+     *             "addresses": [string] // Array of addresses involved in the transaction
+     *           },
+     *           "assets": [ // Optional, present if assets are involved in the input
+     *             {
+     *               "assetId": string, // The asset ID
+     *               "amount": string, // The amount of the asset
+     *               "decimals": int, // Decimals for the asset amount
+     *               "cid": string, // Content identifier, present only for non-aggregable assets
+     *               "rules": boolean // Rules applied to the asset, true or undefined
+     *             }
+     *           ]
+     *         }
+     *       ],
+     *       "vout": [ // An array of output objects, each Vout object contains:
+     *         {
+     *           "value": string, // The value of the output in satoshis
+     *           "vout": int, // The index of this output in the transaction
+     *           "scriptPubKey": { // The scriptPubKey object contains:
+     *             "asm": string,
+     *             "hex": string,
+     *             "reqSigs": int,
+     *             "type": string,
+     *             "addresses": [string]
+     *           },
+     *           "spent": int, // The height at which the output was spent (optional)
+     *           "assets": [ // Optional, present if assets are involved in the output
+     *             // Same structure as assets in "vin"
+     *           ]
+     *         }
+     *       ],
+     *       "blockhash": string, // The hash of the block containing this transaction
+     *       "height": int, // The height of the block containing this transaction
+     *       "time": int // The time the transaction was included in a block
+     *     }
+     *   ]
+     * }
+     */
+    Json::Value getDigiByteBlockData(const string& hash) {
+        //get the data core wallet has
+        DigiByteCore* dgb=AppMain::GetInstance()->getDigiByteCore();
+        blockinfo_t coreData=dgb->getBlock(hash);
+
+        // Fill in the block information
+        Json::Value result=Json::objectValue;
+        result["hash"] = coreData.hash;
+        result["strippedsize"] = coreData.strippedsize;
+        result["size"] = coreData.size;
+        result["weight"] = coreData.weight;
+        result["height"] = coreData.height;
+        result["version"] = coreData.version;
+        result["pow_algo_id"] = static_cast<int>(coreData.algo);
+        result["time"] = coreData.time;
+        result["mediantime"] = coreData.time;
+        result["difficulty"] = coreData.difficulty;
+        result["nTx"] = static_cast<int>(coreData.tx.size()); // Number of transactions
+        result["previousblockhash"] = coreData.previousblockhash;
+        if (!coreData.nextblockhash.empty()) { // Check if nextblockhash is available
+            result["nextblockhash"] = coreData.nextblockhash;
+        }
+        // Transactions array
+        Json::Value txsArray = Json::arrayValue;
+        for (const std::string& txid : coreData.tx) {
+            Json::Value txData = getTxData(txid);
+            txsArray.append(txData);
+        }
+        result["tx"] = txsArray;
+
+        // Return the fully constructed Json::Value
+        return result;
+    }
+
+    /**
+     * Fetches asset data for a given DigiAsset ID.
+     *
+     * @param assetId The DigiAsset ID to fetch data for.
+     * @return Json::Value containing AssetData with the following structure:
+     * {
+     *   "assetId": string, // The asset ID
+     *   "issuer": string, // The address of the issuer
+     *   "locked": boolean, // Whether the asset is locked
+     *   "aggregation": string, // Aggregation policy ('aggregatable', 'hybrid', 'dispersed')
+     *   "divisibility": int, // The divisibility of the asset
+     *   "holders": { // A map of addresses to their respective balances
+     *     "address": string|BigInt, // The balance of the asset held by the address
+     *     ...divisibility
+     *   },
+     *   "supply": { // Information about the asset's supply
+     *     "initial": string|BigInt, // The initial supply of the asset
+     *     "current": string|BigInt, // The current supply of the asset
+     *   },
+     *   "metadata": [ // An array of metadata objects
+     *     {
+     *       "txid": string, // The transaction ID where the metadata was recorded
+     *       "cid": string, // The content identifier for the metadata
+     *     },
+     *     ...
+     *   ],
+     *   "rules": [ // Optional, an array of AssetRules objects if any rules are defined
+     *     {
+     *       "rewritable": boolean, // Whether the rules are rewritable
+     *       "effective": int, // The block height at which the rules became effective
+     *       "signers": { // Optional, information about signers if present
+     *         "required": int, // The number of required signers
+     *         "list": { // A map of signer addresses to their respective weights
+     *           "address": int,
+     *           ...
+     *         },
+     *       },
+     *       "royalties": { // Optional, a map of addresses to their respective royalty percentages
+     *         "address": int|BigInt,
+     *         ...
+     *       },
+     *       "kyc": { // Optional, KYC requirements
+     *         "allow": [string], // Allowed countries or addresses
+     *         "ban": [string], // Banned countries or addresses
+     *       }|boolean, // True if KYC is required, false or undefined otherwise
+     *       "vote": { // Optional, information about voting
+     *         "options": [ // Voting options
+     *           {
+     *             "label": string, // The label of the option
+     *             "address": string, // The address associated with the option
+     *           },
+     *           ...
+     *         ],
+     *         "movable": boolean, // Whether the vote is movable
+     *         "cutoff": int|BigInt, // The cutoff block height for the vote
+     *       },
+     *       "currency": { // Optional, the currency used for transactions
+     *         "address": string, // The address of the currency
+     *         "index": int, // The index of the currency
+     *         "name": string, // The name of the currency
+     *       },
+     *       "expires": int|BigInt, // Optional, the block height at which the asset expires
+     *       "deflate": int|BigInt, // Optional, the deflation rate of the asset
+     *     },
+     *     ...
+     *   ],
+     *   "txs": [ // An array of AssetTxRecord objects representing asset transactions
+     *     {
+     *       "time": int, // The transaction time
+     *       "height": int, // The block height of the transaction
+     *       "txid": string, // The transaction ID
+     *       "type": string, // The type of transaction
+     *       "input": { // A map of input assets
+     *         "address": string|BigInt,
+     *         ...
+     *       },
+     *       "output": { // A map of output assets
+     *         "address": string|BigInt,
+     *         ...
+     *       },
+     *     },
+     *     ...
+     *   ],
+     *   "votes": [ // Optional, an array of vote records if any votes are associated with the asset
+     *     {
+     *       "label": string, // The label of the vote
+     *       "address": string, // The address associated with the vote
+     *       "count": int, // The number of votes
+     *     },
+     *     ...
+     *   ],
+     *   "firstUsed": int, // The block height at which the asset was first used
+     *   "lastUsed": int, // The block height at which the asset was last used
+     *   "expired": boolean, // Whether the asset is expired
+     *   "kyc": { // Optional, KYC state of the asset
+     *     "country": string, // The country code
+     *     "name": string, // The name of the individual or entity
+     *     "hash": string, // A hash representing the individual or entity
+     *     "revoked": int, // The block height at which the KYC status was revoked (optional)
+     *   }
+     * }
+     */
+    Json::Value getAssetData(const std::string& assetId) {
+        Json::Value results=Json::objectValue;
+        results["expired"]=false;   //will set true later if expired
+
+        //get list of assetIndexes this could be
+        Database* db = AppMain::GetInstance()->getDatabase();
+        vector<uint64_t> assetIndexes = db->getAssetIndexes(assetId);
+
+        //get the data that is common to all assets
+        DigiAsset asset=db->getAsset(assetIndexes[0]);
+        Json::Value json = asset.toJSON(false);
+
+        //handle basic info
+        results["assetId"]=json["assetId"];
+        results["issuer"]=json["issuer"]["address"];
+        results["locked"]=(assetId[0]=='L');
+        switch (assetId[1]) {
+            case 'a':
+                results["aggregation"]="aggregatable";
+                break;
+            case 'h':
+                results["aggregation"]="hybrid";
+                break;
+            case 'd':
+                results["aggregation"]="dispersed";
+                break;
+        }
+        results["divisibility"]=json["decimals"];
+
+        //handle rules
+        if (json.isMember("rules")) {
+            Json::Value refRules=json["rules"];
+
+            Json::Value rules=Json::objectValue;
+            rules["rewritable"]=refRules["changeable"];
+            //rules["effective"]: int, // The block height at which the rules became effective
+            if (refRules.isMember("approval")) {
+                Json::Value signers=Json::objectValue;
+                signers["required"]=refRules["approval"]["required"];
+                signers["list"]=refRules["approval"]["approvers"];
+                rules["signers"]=signers;
+            }
+            if (refRules.isMember("royalty")) {
+                rules["royalties"]=refRules["royalty"]["addresses"];
+                if (refRules["royalty"].isMember("units")) {
+                    rules["currency"]=refRules["royalty"]["units"];
+                }
+            }
+            if (refRules.isMember("geofence")) {
+                if (refRules["geofence"].isMember("denied")) {
+                    if (refRules["geofence"]["denied"].empty()) {
+                        rules["kyc"]=true;
+                    } else {
+                        rules["kyc"] = Json::objectValue;
+                        rules["kyc"]["ban"] = refRules["geofence"]["denied"];
+                    }
+                }
+                if (refRules["geofence"].isMember("allowed")) {
+                    rules["kyc"]=Json::objectValue;
+                    rules["kyc"]["allow"]=refRules["geofence"]["allowed"];
+                }
+            }
+            if (refRules.isMember("voting")) {
+                Json::Value vote=Json::objectValue;
+                vote["movable"]=refRules["voting"]["restricted"];
+
+                //convert vote options
+                Json::Value optionsArray = Json::arrayValue;
+                const Json::Value& options = refRules["voting"]["options"];
+                for (Json::ValueConstIterator it = options.begin(); it != options.end(); ++it) {
+                    Json::Value option = Json::objectValue;
+                    option["label"] = it.key().asString(); // Assuming the key itself is the label
+                    option["address"] = it->asString(); // The value is the address
+                    optionsArray.append(option);
+                }
+                vote["options"] = optionsArray;
+
+                //check if expires
+                if (refRules.isMember("expiry")) {
+                    vote["cutoff"]=refRules["expiry"];
+                }
+                rules["vote"]=vote;
+            } else {
+                if (refRules.isMember("expiry")) {
+                    rules["expires"]=refRules["expiry"];
+                }
+            }
+            if (refRules.isMember("deflation")) {
+                rules["deflate"]=refRules["deflation"];
+            }
+            results["rules"]=rules;
+
+            //check if expired
+            if (refRules.isMember("expiry")) {
+                unsigned int heightExpires=refRules["expiry"].asUInt();
+                unsigned int heightSynced=AppMain::GetInstance()->getChainAnalyzer()->getSyncHeight();
+                if (heightExpires<heightSynced) results["expired"]=true;
+            }
+        }
+
+        //handle txs
+        results["txs"]=Json::arrayValue;
+        vector<string> txids=db->getAssetTxHistory(assetId);
+        for (const string& txid: txids) {
+            Json::Value entry=Json::objectValue;
+            DigiByteTransaction tx(txid);
+            entry["time"]=0;//cheat probably doesn't matter so not bothering  value 0 is obviously wrong
+            entry["height"]=tx.getHeight();
+            entry["txid"]=txid;
+            string type="Transfer";
+            if (tx.isBurn(false)) type="Burn";
+            if (tx.isUnintentionalBurn()) type="Accidental Burn";
+            if (tx.isIssuance()) type="Issuance";
+            entry["type"]=type;
+
+            //get inputs
+            Json::Value inputs=Json::objectValue;
+            for (size_t i=0;i<tx.getInputCount();i++) {
+                auto input=tx.getInput(i);
+                uint64_t count=0;
+                for (const auto& assetInput: input.assets) {
+                    if (assetId==assetInput.getAssetId()) {
+                        count+=assetInput.getCount();
+                    }
+                }
+                if (count==0) continue;
+                if (!inputs.isMember(input.address)) inputs[input.address]=0;
+                inputs[input.address]=inputs[input.address].asUInt64()+count;
+            }
+            entry["input"]=inputs;
+
+            //get outputs
+            Json::Value outputs=Json::objectValue;
+            for (size_t i=0;i<tx.getOutputCount();i++) {
+                auto output =tx.getOutput(i);
+                uint64_t count=0;
+                for (const auto& assetOutput: output.assets) {
+                    if (assetId==assetOutput.getAssetId()) {
+                        count+=assetOutput.getCount();
+                    }
+                }
+                if (count==0) continue;
+                if (!outputs.isMember(output.address)) outputs[output.address]=0;
+                outputs[output.address]=outputs[output.address].asUInt64()+count;
+            }
+            entry["output"]=outputs;
+
+            results["txs"].append(entry);
+        }
+
+        //votes
+        map<string,uint64_t> voteMap;
+        for (uint64_t assetIndex : assetIndexes) {
+            auto votesData = db->getVoteCounts(assetIndex);
+            for (const auto& vote: votesData) {
+                voteMap[vote.address]+=vote.count;
+            }
+        }
+        if (!voteMap.empty()) {
+            Json::Value votes=Json::arrayValue;
+            for (const auto& entry : voteMap) {
+                Json::Value voteObject(Json::objectValue); // Create a JSON object for each map entry
+                voteObject["label"] = "NA"; //hack
+                voteObject["address"] = entry.first;  // The map key becomes "label"
+                voteObject["count"] = Json::Value::UInt64(entry.second); // The map value becomes "count", ensure to cast to UInt64 if necessary
+
+                votes.append(voteObject); // Append the object to the array
+            }
+            results["votes"]=votes;
+        }
+
+        //handle first and last
+        results["firstUsed"]=asset.getHeightCreated();
+        results["lastUsed"]=asset.getHeightUpdated();   //cheat not correct value but using it
+
+        //handle kyc
+        if (json["issuer"].isMember("country")) {
+            Json::Value kyc=Json::objectValue;
+            kyc["country"]=json["issuer"]["country"];
+            if (json["issuer"].isMember("name")) {
+                kyc["name"]=json["issuer"]["name"];
+            }
+            if (json["issuer"].isMember("hash")) {
+                kyc["hash"]=json["issuer"]["hash"];
+            }
+            results["kyc"]=kyc;
+        }
+
+        //handle holders
+        unordered_map<std::string, uint64_t> aggregatedHoldings;
+        uint64_t totalSupply = 0;
+        uint64_t originalSupply = 0;
+        for (uint64_t assetIndex : assetIndexes) {
+            originalSupply += db->getOriginalAssetCount(assetIndex);
+            std::vector<AssetHolder> holders = db->getAssetHolders(assetIndex);
+            for (const AssetHolder& holder : holders) {
+                aggregatedHoldings[holder.address] += holder.count;
+                totalSupply += holder.count;
+            }
+        }
+        Json::Value holdersJson = Json::objectValue;
+        for (const auto& pair : aggregatedHoldings) {
+            holdersJson[pair.first] = Json::Value(static_cast<Json::UInt64>(pair.second));
+        }
+        results["holders"] = holdersJson;
+
+        //handle supply
+        results["supply"] = Json::objectValue;
+        results["supply"]["current"] = Json::Value(static_cast<Json::UInt64>(totalSupply));
+        results["supply"]["initial"] = Json::Value(static_cast<Json::UInt64>(originalSupply));
+
+        //handle metadata
+        Json::Value metadata=Json::arrayValue;
+        for (uint64_t assetIndex : assetIndexes) {
+            Json::Value entry=Json::objectValue;
+            entry["txid"]="0000000000000000000000000000000000000000000000000000000000000000";//hack obviously fake
+            entry["cid"]=db->getAsset(assetIndex).getCID();
+            metadata.append(entry);
+        }
+        results["metadata"]=metadata;
+
+        return results;
+    }
+
+    /**
+     * Retrieves the current blockchain height.
+     *
+     * @return Json::Value containing an integer representing the current sync height.
+     */
+    Json::Value getHeight() {
+        return AppMain::GetInstance()->getChainAnalyzer()->getSyncHeight();
+    }
+
+    /**
+     * Fetches UTXO (Unspent Transaction Outputs) data for a given address.
+     * warning will only return non asset utxo if the address is part of your wallet or non asset utxo is being stored.
+     *
+     * @param address The address to fetch UTXO data for.
+     * @return Json::Value containing an array of UTXO objects for the specified address, with each object structured as follows:
+     * [
+     *   {
+     *     "txid": string, // The transaction ID where this UTXO was created
+     *     "vout": int, // The output index in the transaction, identifying this specific UTXO
+     *     "value": string|BigInt, // The amount of satoshis or asset units this UTXO holds
+     *     "scriptPubKey": { // The scriptPubKey object associated with this UTXO, containing:
+     *       "asm": string, // Assembly notation of the script
+     *       "hex": string, // Hexadecimal representation of the script
+     *       "reqSigs": int, // Number of required signatures to spend this UTXO
+     *       "type": string, // Type of script (e.g., 'pubkeyhash')
+     *       "addresses": [string] // Array of addresses involved in this UTXO
+     *     },
+     *     "assets": [ // Optional, present if assets are involved in this UTXO, each AssetCount object contains:
+     *       {
+     *         "assetId": string, // The asset ID
+     *         "amount": string|BigInt, // The amount of the asset
+     *         "decimals": int, // Decimals for the asset amount
+     *         "cid": string, // Content identifier, present only for non-aggregable assets
+     *         "rules": boolean // Rules applied to the asset, true or undefined
+     *       }
+     *     ]
+     *   },
+     *   ...
+     * ]
+     *
+     * This function returns detailed information about each UTXO held by the specified address, including any associated assets.
+     */
+    Json::Value getAddressUtxoData(const std::string& address) {
+        //get unspent utxo on the current address
+        Database* db=AppMain::GetInstance()->getDatabase();
+        DigiByteCore* dgb=AppMain::GetInstance()->getDigiByteCore();
+        auto utxos=db->getAddressUTXOs(address);
+
+        //convert to old format
+        Json::Value results=Json::arrayValue;
+        for (const auto& utxo: utxos) {
+            //copy basic info
+            Json::Value entry=Json::objectValue;
+            entry["txid"]=utxo.txid;
+            entry["vout"]=utxo.vout;
+            entry["value"]=utxo.digibyte;
+            entry["scriptPubKey"]=Json::objectValue;
+            entry["scriptPubKey"]["hex"]=dgb->getAddressInfo(address).scriptPubKey;
+            entry["scriptPubKey"]["asm"]="";//hack
+            entry["scriptPubKey"]["reqSigs"]=1;//hack
+            entry["scriptPubKey"]["type"]="pubkeyhash";//hack
+            entry["scriptPubKey"]["addresses"]=Json::arrayValue;
+            entry["scriptPubKey"]["addresses"].append(Json::Value(address));
+
+            //copy assets
+            Json::Value assets=Json::arrayValue;
+            for (const auto& asset: utxo.assets) {
+                Json::Value assetEntry=Json::objectValue;
+                assetEntry["assetId"]=asset.getAssetId();
+                assetEntry["amount"]=asset.getCount();
+                assetEntry["decimals"]=asset.getDecimals();
+                if (!asset.isAggregable()) {
+                    assetEntry["cid"]=asset.getCID();
+                }
+                assetEntry["rules"]=!asset.getRules().empty();
+                assets.append(assetEntry);
+            }
+            if (!assets.empty()) {
+                entry["assets"]=assets;
+            }
+
+            results.append(entry);
+        }
+        return results;
+    }
+
+    /**
+     * Fetches comprehensive data associated with a given address.
+     * Warning txs will only list DigiAsset transactions if wallet isn't storing non asset utxos
+     *
+     * @param address The address to fetch data for.
+     * @return Json::Value containing AddressData with the following structure:
+     * {
+     *   "address": string, // The queried address
+     *   "index": int, // An index number associated with the address (if applicable)
+     *   "group": int, // Group ID the address belongs to (if applicable)
+     *   "firstUsed": int, // The block height at which the address was first used
+     *   "lastUsed": int, // The block height at which the address was last used
+     *   "txs": [ // An array of AddressTxRecord objects, each containing:
+     *     {
+     *       "assetId": string, // The asset ID involved in the transaction (optional)
+     *       "time": int, // The timestamp of the transaction
+     *       "height": int, // The block height of the transaction
+     *       "txid": string, // The transaction ID
+     *       "change": string|BigInt, // The change in balance from the transaction (can be negative)
+     *       "balance": string|BigInt, // The new balance of the address after the transaction
+     *     },
+     *     ...
+     *   ],
+     *   "deposit": { // Aggregate deposit information, structured as DepositWithdraw:
+     *     "min": string|BigInt, // The minimum deposit amount
+     *     "max": string|BigInt, // The maximum deposit amount
+     *     "sum": string|BigInt, // The total sum of deposits
+     *     "count": int, // The count of deposit transactions
+     *   },
+     *   "withdraw": { // Optional, aggregate withdrawal information, similar structure as deposit
+     *     "min": string|BigInt,
+     *     "max": string|BigInt,
+     *     "sum": string|BigInt,
+     *     "count": int,
+     *   },
+     *   "assets": { // A map of asset IDs to their respective balances held by the address
+     *     "assetId": string|BigInt,
+     *     ...
+     *   },
+     *   "kyc": { // Optional, KYC state of the address, structured as KycState:
+     *     "country": string, // The country code
+     *     "name": string, // The name of the individual or entity (optional)
+     *     "hash": string, // A hash representing the individual or entity (optional)
+     *     "revoked": int, // The block height at which the KYC status was revoked (optional)
+     *   },
+     *   "issuance": [ // Optional, an array of asset IDs issued by the address
+     *     string,
+     *     ...
+     *   ]
+     * }
+     *
+     * This function returns a comprehensive overview of the address, including transaction records, balance changes, asset holdings, KYC information, and any assets issued by the address.
+     */
+    Json::Value getAddressData(const std::string& address) {
+        Database* db=AppMain::GetInstance()->getDatabase();
+
+        map<unsigned int,int64_t> balances; //todo should be uint64_t but needs to be int64_t until database fixed
+        map<unsigned int,string> assetIds;
+        bool processDigiByte=!db->getBeenPrunedNonAssetUTXOHistory();
+
+        Json::Value result=Json::objectValue;
+        result["address"]=address;
+        result["index"]=0;  //not tracked
+        result["group"]=0;  //not tracked
+        result["firstUsed"]=0;  //hack
+        result["lastUsed"]=0;   //hack
+        Json::Value txs=Json::arrayValue;
+        vector<string> txidList=db->getAddressTxList(address);
+        for (const auto& txid: txidList) {
+            map<unsigned int,int64_t> changes;
+
+            //load the transaction in question
+            DigiByteTransaction tx(txid);
+
+            //process inputs
+            for (size_t i=0;i<tx.getInputCount();i++) {
+                AssetUTXO input=tx.getInput(i);         //get input info
+                if (input.address!=address) continue;      //skip if not related to this address
+
+                //handle digibyte
+                if (processDigiByte) {
+                    balances[1]-=input.digibyte;
+                    changes[1]-=static_cast<int64_t>(input.digibyte);
+                }
+                for (const auto& asset: input.assets) {
+                    unsigned int assetIndex=asset.getAssetIndex();
+                    balances[assetIndex]-=asset.getCount();
+                    changes[assetIndex]-=static_cast<int64_t>(asset.getCount());
+                    assetIds[assetIndex]=asset.getAssetId();
+                }
+            }
+
+            //process outputs
+            for (size_t i=0;i<tx.getOutputCount();i++) {
+                AssetUTXO output =tx.getOutput(i);         //get output info
+                if (output.address!=address) continue;      //skip if not related to this address
+
+                //handle digibyte
+                if (processDigiByte) {
+                    balances[1]+= output.digibyte;
+                    changes[1]+= static_cast<int64_t>(output.digibyte);
+                }
+                for (const auto& asset: output.assets) {
+                    unsigned int assetIndex=asset.getAssetIndex();
+                    balances[assetIndex]+=asset.getCount();
+                    changes[assetIndex]+=static_cast<int64_t>(asset.getCount());
+                    assetIds[assetIndex]=asset.getAssetId();
+                }
+            }
+
+            //convert results to desired format
+            for (const auto& change : changes) {
+                unsigned int assetIndex = change.first;
+                int64_t changeAmount = change.second;
+
+                Json::Value transaction;
+                if (assetIndex!=1) transaction["assetId"] = assetIds[assetIndex];
+                transaction["time"] = Json::Value::Int64(0); // Placeholder for timestamp, replace 0 with actual timestamp if available
+                transaction["height"] = tx.getHeight();
+                transaction["txid"] = txid;
+                transaction["change"] = Json::Value::Int64(changeAmount);
+                transaction["balance"] = Json::Value::UInt64(balances[assetIndex]);
+                txs.append(transaction);
+            }
+        }
+        result["txs"]=txs;
+
+        //hack to create withdraw and withdraw that shows the balance we know but doesn't bother with real numbers
+        Json::Value withdraw =Json::objectValue;
+        withdraw["min"]=0;
+        withdraw["max"]=0;
+        withdraw["sum"]=0;
+        withdraw["count"]=0;
+        result["withdraw"]= withdraw;
+        Json::Value deposit=Json::objectValue;
+        deposit["min"]=0;
+        deposit["max"]=balances[1];
+        deposit["sum"]=balances[1];
+        deposit["count"]=1;
+        result["deposit"]=deposit;
+
+        //create the assets entry
+        Json::Value assets=Json::objectValue;
+        for (const auto& pair : assetIds) {
+            unsigned int assetIndex = pair.first;
+            const string& assetId = pair.second;
+            if (assetIndex==1) continue;    //skip DigiByte
+            uint64_t balance = balances[assetIndex];
+            if (!assets.isMember(assetId)) assets[assetId]=0;
+            assets[assetId] = Json::Value::UInt64(assets[assetId].asUInt64() + balance);
+        }
+        result["assets"]=assets;
+
+        //get kyc data
+        KYC kycData=db->getAddressKYC(address);
+        if (!kycData.empty()) {
+            Json::Value kyc=Json::objectValue;
+            kyc["country"]=kycData.getCountry();
+            string hash=kycData.getHash();
+            if (hash.empty()) {
+                kyc["name"]=kycData.getName();
+            } else {
+                kyc["hash"]=hash;
+            }
+            if (!kycData.valid()) {
+                kyc["revoked"]=kycData.getHeightRevoked();
+            }
+            result["kyc"]=kyc;
+        }
+
+        //get issuance
+        Json::Value issuance=Json::arrayValue;
+        set<string> uniqueAssetIds;
+        vector<uint64_t> createdAssets=db->getAssetsCreatedByAddress(address);
+        for (uint64_t assetIndex: createdAssets) {
+            string assetId=db->getAsset(assetIndex).getAssetId();
+            if (uniqueAssetIds.insert(assetId).second) {    //make sure unique
+                issuance.append(assetId);
+            }
+        }
+        if (!issuance.empty()) result["issuance"]=issuance;
+
+        return result;
+    }
+
+
+
+
+
+
+    Json::Value getKey(unsigned int key) {
+        string hash=AppMain::GetInstance()->getDigiByteCore()->getBlockHash(key);
+        return getDigiByteBlockData(hash);
+    }
+    Json::Value getKey(const string& key) {
+        if (key.empty()) return Json::objectValue;  //just return empty for empty key
+
+        //check if key is a hash
+        if (key.length()==64) {
+            //probably a sha256
+            unsigned int height;
+            try {
+                //check if it is a block hash
+                Json::Value result=getDigiByteBlockData(key);
+                return result;
+            } catch (...) {
+                //not a block hash so assume it is a txid
+                return getTxData(key);
+            }
+        }
+
+        //check if key is a DigiAsset
+        if (key[0]=='U' || key[0]=='L') {
+            return getAssetData(key);
+        }
+
+        //check if key is specialty command
+        if (key=="height") {
+            return getHeight();
+        }
+
+        //check if key is looking for utxo data
+        const std::string suffix = "_utxos";
+        if ((key.length() > 6) && (0 == key.compare(key.length() - suffix.length(), suffix.length(), suffix))) {
+            return getAddressUtxoData(key.substr(0,key.length()-6));
+        }
+
+        //check if unsupported keys
+        if (key.substr(0,6)=="index_") throw exception();
+        if (key.substr(0,5)=="data_") throw exception();
+
+        //assume address if left over
+        return getAddressData(key);
+    }
+}

--- a/src/OldStream.cpp
+++ b/src/OldStream.cpp
@@ -6,6 +6,7 @@
 #include "AppMain.h"
 #include "Database.h"
 #include "Log.h"
+#include "utils.h"
 #include <jsonrpccpp/client.h>
 #include <jsonrpccpp/client/connectors/httpclient.h>
 #include <set>
@@ -798,12 +799,14 @@ namespace OldStream {
 
 
 
-    Json::Value getKey(unsigned int key) {
-        string hash=AppMain::GetInstance()->getDigiByteCore()->getBlockHash(key);
-        return getDigiByteBlockData(hash);
-    }
     Json::Value getKey(const string& key) {
         if (key.empty()) return Json::objectValue;  //just return empty for empty key
+
+        //check if key is integer
+        if (utils::isInteger(key)) {
+            string hash=AppMain::GetInstance()->getDigiByteCore()->getBlockHash(atoi(key.c_str()));
+            return getDigiByteBlockData(hash);
+        }
 
         //check if key is a hash
         if (key.length()==64) {

--- a/src/OldStream.h
+++ b/src/OldStream.h
@@ -1,0 +1,15 @@
+//
+// Created by mctrivia on 26/02/24.
+//
+
+#ifndef DIGIASSET_CORE_OLDSTREAM_H
+#define DIGIASSET_CORE_OLDSTREAM_H
+
+
+#include <jsoncpp/json/value.h>
+namespace OldStream {
+    Json::Value getKey(unsigned int key);
+    Json::Value getKey(const std::string& key);
+}
+
+#endif //DIGIASSET_CORE_OLDSTREAM_H

--- a/src/PermanentStoragePool/PermanentStoragePool.cpp
+++ b/src/PermanentStoragePool/PermanentStoragePool.cpp
@@ -5,6 +5,7 @@
 #include "PermanentStoragePool.h"
 #include "AppMain.h"
 #include "Config.h"
+#include "Log.h"
 #include "static_block.hpp"
 
 
@@ -29,7 +30,13 @@ void PermanentStoragePool::setPoolIndexAndInitialize(unsigned int index, const C
             vector<string> addresses = dgb->getaddressesbylabel(_payoutAddress);
             _payoutAddress = addresses[0];
         } catch (const DigiByteException& e) {
-            _payoutAddress = dgb->getnewaddress(_payoutAddress);
+            try {
+                _payoutAddress = dgb->getnewaddress(_payoutAddress);
+            } catch (const DigiByteException& e) {
+                Log* log=Log::GetInstance();
+                log->addMessage("Could not generate new PSP payout address",Log::CRITICAL);
+                throw;
+            }
         }
     }
 

--- a/src/PermanentStoragePool/pools/mctrivia.cpp
+++ b/src/PermanentStoragePool/pools/mctrivia.cpp
@@ -235,6 +235,10 @@ void mctrivia::_callServer(ServerCalls command, const string& extra) {
                             {"peerId", peerId},
                             {"visible", (_visible ? "v" : "h")},
                             {"secret", _secretCode}});
+    if (command==KEEP_ALIVE) {
+        Log* log=Log::GetInstance();
+        log->addMessage("Reported online to ipfs.digiassetx.com with server id: "+peerId);
+    }
 
     //update the bad list
     updateBadList();

--- a/src/UniqueTaskQueue.cpp
+++ b/src/UniqueTaskQueue.cpp
@@ -1,0 +1,48 @@
+//
+// Created by mctrivia on 08/03/24.
+//
+
+#include "UniqueTaskQueue.h"
+#include <queue>
+#include <unordered_set>
+#include <mutex>
+#include <string>
+#include <condition_variable>
+
+using namespace std;
+
+// Adds a task to the queue if it's not already present
+bool UniqueTaskQueue::enqueue(const string& task) {
+    unique_lock<mutex> lock(_mutex);
+    if (_set.find(task) == _set.end()) {
+        _queue.push(task);
+        _set.insert(task);
+        lock.unlock();
+        _cond.notify_one(); // Notify one waiting thread
+        return true;
+    }
+    return false; // Task was already in the set
+}
+
+// Retrieves and removes the next task from the queue
+// Blocks if the queue is empty until a new task is added
+string UniqueTaskQueue::dequeue() {
+    unique_lock<mutex> lock(_mutex);
+    _cond.wait(lock, [this] { return !_queue.empty(); }); // Wait until the queue is not empty
+
+    string task = _queue.front();
+    _queue.pop();
+    _set.erase(task);
+    return task;
+}
+
+// Checks if the queue is empty (primarily for testing or conditional processing)
+bool UniqueTaskQueue::isEmpty() {
+    lock_guard<mutex> lock(_mutex);
+    return _queue.empty();
+}
+
+unsigned int UniqueTaskQueue::length() {
+    lock_guard<mutex> lock(_mutex);
+    return _queue.size();
+}

--- a/src/UniqueTaskQueue.h
+++ b/src/UniqueTaskQueue.h
@@ -1,0 +1,37 @@
+//
+// Created by mctrivia on 08/03/24.
+//
+
+#ifndef DIGIASSET_CORE_UNIQUETASKQUEUE_H
+#define DIGIASSET_CORE_UNIQUETASKQUEUE_H
+
+
+
+#include <queue>
+#include <unordered_set>
+#include <mutex>
+#include <string>
+#include <condition_variable>
+class UniqueTaskQueue {
+private:
+    std::mutex _mutex;
+    std::condition_variable _cond;
+    std::queue<std::string> _queue;
+    std::unordered_set<std::string> _set;
+
+public:
+    // Adds a task to the queue if it's not already present
+    bool enqueue(const std::string& task);
+
+    // Retrieves and removes the next task from the queue
+    // Blocks if the queue is empty until a new task is added
+    std::string dequeue();
+
+    // Checks if the queue is empty (primarily for testing or conditional processing)
+    bool isEmpty();
+    unsigned int length();
+};
+
+
+
+#endif //DIGIASSET_CORE_UNIQUETASKQUEUE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@ int main() {
      */
     unsigned int pauseHeight = 0;
     if (config.getBool("bootstrapchainstate", true) && !utils::fileExists("chain.db")) {
+        log->addMessage("Bootstraping Database.  This may take a while depending on how faster your internet is.");
         IPFS ipfs("config.cfg", false);
         ipfs.downloadFile("Qme6x3nU9TuLxjGhhBWNoKMcKWA44w2z1v5rSHZHd4j2jF", "chain.db", true);
         pauseHeight = 18738063; ///when updating images always set this to 1 greater than largest height in blocks table
@@ -95,6 +96,7 @@ int main() {
     ChainAnalyzer analyzer;
     analyzer.loadConfig();
     analyzer.start();
+    main->setChainAnalyzer(&analyzer);
     //analyzer.stop();
 
     /**
@@ -103,7 +105,7 @@ int main() {
 
     try {
         // Create and start the Bitcoin RPC server
-        BitcoinRpcServer server(dgb, analyzer);
+        BitcoinRpcServer server;
         server.start();
 
     } catch (const std::exception& e) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,8 +32,8 @@ int main() {
     if (config.getBool("bootstrapchainstate", true) && !utils::fileExists("chain.db")) {
         log->addMessage("Bootstraping Database.  This may take a while depending on how faster your internet is.");
         IPFS ipfs("config.cfg", false);
-        ipfs.downloadFile("Qme6x3nU9TuLxjGhhBWNoKMcKWA44w2z1v5rSHZHd4j2jF", "chain.db", true);
-        pauseHeight = 18738063; ///when updating images always set this to 1 greater than largest height in blocks table
+        ipfs.downloadFile("QmVYaAEq5Whh1951RtRrBx1aFXiLuPoho4apRRa9tX6BDM", "chain.db", true);
+        pauseHeight = 18927358; ///when updating images always set this to 1 greater than largest height in blocks table
     }
 
     /*

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -67,4 +67,16 @@ namespace utils {
         struct stat buffer {};
         return (stat(fileName.c_str(), &buffer) == 0);
     }
+
+    /**
+     * Returns if a string contains an integer
+     * @param s
+     * @return
+     */
+    bool isInteger(const std::string& s) {
+        std::istringstream iss(s);
+        int n;
+        iss >> n;
+        return iss.eof() && !iss.fail(); // Check if reading was successful and the entire string was consumed
+    }
 } // namespace utils

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,9 +3,11 @@
 //
 
 #include "utils.h"
+#include <jsoncpp/json/value.h>
 #include <random>
 #include <sstream>
 #include <sys/stat.h>
+#include <iostream>
 
 namespace utils {
 
@@ -78,5 +80,13 @@ namespace utils {
         int n;
         iss >> n;
         return iss.eof() && !iss.fail(); // Check if reading was successful and the entire string was consumed
+    }
+
+    /**
+     * Function to help debug Json values
+     * @param params
+     */
+    void printJson(const Json::Value& params) {
+        std::cout << params.toStyledString() << std::endl;
     }
 } // namespace utils

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,6 +5,7 @@
 #ifndef DIGIASSET_CORE_UTILS_H
 #define DIGIASSET_CORE_UTILS_H
 
+#include <jsoncpp/json/value.h>
 #include <string>
 #include <vector>
 namespace utils {
@@ -19,6 +20,7 @@ namespace utils {
     std::string generateRandom(unsigned char length, CodeType type);
     bool fileExists(const std::string& fileName);
     bool isInteger(const std::string& s);
+    void printJson(const Json::Value& params);  //added to make debugging easier
 
 } // namespace utils
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,6 +18,7 @@ namespace utils {
     std::vector<std::string> split(const std::string& s, char delimiter);
     std::string generateRandom(unsigned char length, CodeType type);
     bool fileExists(const std::string& fileName);
+    bool isInteger(const std::string& s);
 
 } // namespace utils
 


### PR DESCRIPTION
-added error handling around payout address
-added message about psp mctrivia reporting id
-added rpc call to simulate most of digiassetX stream.  this is imedietly deprecated and should only be used as stop gap to help converting away from stream.  No new code should use this because it is very inefficient and will eventually be removed.
-added issuance and spent txid flags to the utxo table.  this change is not backwards compatible but will allow for a lot of useful information to be gathered.
-added locks to all database queries to prevent multi threading issues
-modify listunspent rpc call to work with digiassets
-fix cli utility, so it will work with json inputs
-update database bootstrap