### PR TITLE
Include numeric for std::accumulate

### DIFF
--- a/src/RPC/Methods/listunspent.cpp
+++ b/src/RPC/Methods/listunspent.cpp
@@ -6,6 +6,7 @@
 #include "RPC/Response.h"
 #include "RPC/Server.h"
 #include <jsoncpp/json/value.h>
+#include <numeric>
 
 namespace RPC {
     namespace Methods {


### PR DESCRIPTION
MSCV needs to include this header explicitly in order to find std::accumulate.