### PR TITLE
fix: GCC 13+ build and RPC passwords with special characters

### DIFF
--- a/src/Blob.h
+++ b/src/Blob.h
@@ -6,6 +6,7 @@
 #define DIGIBYTECORE_BLOB_H
 
 
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <vector>

--- a/src/DigiByteCore.cpp
+++ b/src/DigiByteCore.cpp
@@ -18,6 +18,25 @@
 using jsonrpc::Client;
 using jsonrpc::JSONRPC_CLIENT_V1;
 
+/**
+ * URL-encode a string for safe use in HTTP basic auth URLs.
+ * Characters like /, +, =, @ in RPC passwords would otherwise
+ * break the URL parsing in jsonrpc::HttpClient.
+ */
+static std::string urlEncode(const std::string& value) {
+    std::string encoded;
+    for (unsigned char c : value) {
+        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+            encoded += c;
+        } else {
+            char buf[4];
+            snprintf(buf, sizeof(buf), "%%%02X", c);
+            encoded += buf;
+        }
+    }
+    return encoded;
+}
+
 using jsonrpc::HttpClient;
 using jsonrpc::JsonRpcException;
 
@@ -90,8 +109,8 @@ void DigiByteCore::makeConnection() {
     //see if core is online and config if valid
     try {
         httpClient.reset(new jsonrpc::HttpClient(
-                "http://" + config.getString("rpcuser") + ":" +
-                config.getString("rpcpassword") + "@" +
+                "http://" + urlEncode(config.getString("rpcuser")) + ":" +
+                urlEncode(config.getString("rpcpassword")) + "@" +
                 config.getString("rpcbind", "127.0.0.1") + ":" +
                 std::to_string(_useAssetPort ? config.getInteger("rpcassetport", 14024) : config.getInteger("rpcport", 14022))));
         client.reset(new jsonrpc::Client(*httpClient, jsonrpc::JSONRPC_CLIENT_V1));


### PR DESCRIPTION
## Summary
- Add missing `#include <cstdint>` to `Blob.h` — GCC 13 (Ubuntu 24.04) no longer implicitly includes it, causing build failure on `uint8_t` references
- URL-encode `rpcuser` and `rpcpassword` when constructing the HTTP basic auth URL — passwords containing `/`, `+`, `=`, or `@` broke URL parsing and caused false "DigiByte Core Offline" errors

## Context
Discovered while building on Ubuntu 24.04 LTS with GCC 13.3.0. The `cstdint` issue is a [known GCC 13 change](https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes) affecting many C++ projects. The URL encoding issue affects anyone whose `digibyte.conf` has an auto-generated `rpcpassword` containing base64 characters.

## Test plan
- [x] Verified build succeeds on Ubuntu 24.04 with GCC 13.3.0
- [x] Verified RPC connection works with password containing `/`, `+`, `=`
- [x] Verified chain sync starts successfully after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)